### PR TITLE
Better document and extend Importer

### DIFF
--- a/lib/Catmandu/Importer.pm
+++ b/lib/Catmandu/Importer.pm
@@ -27,16 +27,29 @@ has file => (
 has fh => (
     is      => 'ro',
     lazy    => 1,
-    default => sub { io($_[0]->file, mode => 'r', binmode => $_[0]->encoding) },
+    builder => 1,
 );
 
 has encoding => (
     is       => 'ro',
-    builder  => 'default_encoding',
+    builder  => 1,
 );
 
-sub default_encoding {
+sub _build_encoding {
     ':utf8';
+}
+
+sub _build_fh {
+    # build from file. may be build from URL in a future version
+    io($_[0]->file, mode => 'r', binmode => $_[0]->encoding);
+}
+
+sub readline {
+    $_[0]->fh->getline;
+}
+
+sub readall {
+    join '', $_[0]->fh->getlines;
 }
 
 =head1 NAME
@@ -45,47 +58,65 @@ Catmandu::Importer - Namespace for packages that can import
 
 =head1 SYNOPSIS
 
-    use Catmandu::Importer::JSON;
+    package Catmandu::Importer::Hello;
 
-    my $importer = Catmandu::Importer::JSON->new(file => "/foo/bar.json");
+    use Catmandu::Sane;
+    use Moo;
 
-    my $n = $importer->each(sub {
-        my $hashref = $_[0];
-        # ...
-    });
+    with 'Catmandu::Importer';
 
+    sub generator {
+        my ($self) = @_;
+        state $fh = $self->fh;
+        return sub {
+            my $name = $self->readline;
+            return defined $name ? { "hello" => $name } : undef;
+        };
+    } 
 
 =head1 DESCRIPTION
 
-A Catmandu::Importer is a stub for Perl packages that can import data from
-an external source (a file, the network, ...).
+A Catmandu::Importer is a Perl packages that can import data from an external
+source (a file, the network, ...). Most importers read from an input stream, 
+such as STDIN, a given file, or an URL to fetch data from, so this base class
+provides helper method for consuming the input stream once.
 
 Every Catmandu::Importer is a L<Catmandu::Fixable> and thus provides a 'fix'
 parameter that can be set in the constructor. For every item returned by the
 generator the given fixes will be applied first.
 
+Every Catmandu::Importer is a L<Catmandu::Iterable> and its methods (C<first>,
+C<each>, C<to_array>...) should be used to access items from the importer.
+
+=head1 CONFIGURATION
+
+=over
+
+=item file
+
+Read input from a local file given by its path. Alternatively a scalar
+reference can be passed to read from a string.
+
+=item fh
+
+Read input from an L<IO::Handle>. If not specified, L<Catmandu::Util::io> is used to
+create the input stream from the C<file> argument or by using STDIN.
+
+=item encoding
+
+Binmode of the input stream C<fh>. Set to C<:utf8> by default.
+
+=back
+
 =head1 METHODS
 
-=head2 new(file => $file , encoding => $encoding )
+=head2 readline
 
-Create a new importer reading input from a local file: $file is a string containing the path to
-the file.
+Read a line from the input stream. Equivalent to C<< $importer->fh->getline >>.
 
-=head2 new(fh => $fh , encoding => $encoding)
+=head2 readall
 
-Create a new importer by reading from a IO::Handle. Optionally use Catmandu::Util::io to create IO::Handles.
-
-=head2 count
-
-=head2 each(&callback)
-
-=head2 ...
-
-Every Catmandu::Importer is a L<Catmandu::Iterable> all its methods are inherited.
-
-=head2 log
-
-Return the current logger.
+Read the whole input stream as string.
 
 =head1 SEE ALSO
 

--- a/t/Catmandu-Importer.t
+++ b/t/Catmandu-Importer.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use v5.10.1;
 use Test::More;
 use Test::Exception;
 
@@ -17,11 +18,24 @@ require_ok $pkg;
     use Moo;
     with $pkg;
 
-    sub generator { sub {} }
+    sub generator {
+        my ($self) = @_;
+        state $fh = $self->fh;
+        return sub {
+            my $name = $self->readline;
+            return defined $name ? { "hello" => $name } : undef;
+        };
+    }
 }
 
 my $i = T::Importer->new;
 ok $i->does('Catmandu::Iterable');
 
-done_testing 3;
+$i = T::Importer->new( file => \"World" );
+is_deeply $i->to_array, [{ hello => "World"}], 'import from string reference';
+
+$i = T::Importer->new( file => \"Hello\nWorld" );
+is $i->readall, "Hello\nWorld", "import all";
+
+done_testing;
 


### PR DESCRIPTION
Importers should get the input stream in a consistent way. This change also prepares for https://github.com/LibreCat/Catmandu/issues/58
