### PR TITLE
new 'perlcode' fix

### DIFF
--- a/lib/Catmandu/Fix/perlcode.pm
+++ b/lib/Catmandu/Fix/perlcode.pm
@@ -1,0 +1,83 @@
+package Catmandu::Fix::perlcode;
+
+use Moo;
+use Catmandu::Sane;
+use Catmandu::Fix::Has;
+
+with 'Catmandu::Fix::Base';
+
+our %CACHE;
+
+has file => (
+    fix_arg => 1
+);
+
+has code => (
+    is => 'lazy',
+    builder => sub {
+        my $file = $_[0]->file;
+        $CACHE{ $file } //= do $_[0]->file;
+    }
+);
+
+sub emit {    
+    my ($self, $fixer) = @_;
+
+    my $code   = $fixer->capture($self->code);
+    my $var    = $fixer->var;
+    my $reject = $fixer->capture({});
+
+    "if (${code}->(${var},${reject}) == ${reject}) {"
+    . $fixer->emit_reject .
+    "}"
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Catmandu::Fix::perlcode - execute Perl code as fix function
+
+=head1 DESCRIPTION
+
+Use this fix in the L<Catmandu> fix language to make use of a Perl script:
+
+    perlcode(myscript.pl)
+
+The script (here C<myscript.pl>) must return a code reference:
+
+    sub {
+        my $data = shift;
+        ...
+        return $data;
+    }
+
+When not using the fix language this 
+
+    my $fixer = Catmandu::Fix->new( fixes => [ do 'myscript.pl' ] );
+    $fixer->fix( $item ); 
+
+is roughly equivalent to:
+
+    my $code = do 'myscript.pl';
+    $item = $code->( $item )
+
+All scripts are cached based on their filename, so using this fix multiple
+times will only load each given script once.
+
+The code reference gets passed a second value to reject selected items such as
+possible with see L<Catmandu::Fix::reject>:
+
+    sub {
+        my ($data, $reject) = @_;
+        return rejection_criteria($data) ? $reject : $data;
+    }
+
+To indicate the end processing, return C<undef>.
+
+=head1 SEE ALSO
+
+L<Catmandu::Fix::cmd>
+
+=cut

--- a/t/Catmandu-Fix-perlcode.t
+++ b/t/Catmandu-Fix-perlcode.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More;
+use Catmandu::Fix;
+use Catmandu::Fix::perlcode;
+
+foreach my $i (1..2) { # also tests caching
+    my $fixer = Catmandu::Fix->new( fixes => ['perlcode(t/script.pl)'] );
+    my $data = { };
+    $fixer->fix($data);
+    is_deeply $data, { answer => 42 }, 'perlcode fix';
+}
+
+{
+    my $fixer = Catmandu::Fix->new( fixes => ['perlcode(t/script.pl)'] );
+    is_deeply $fixer->fix([
+        map { +{ answer => $_ } } 1..3
+    ]), [ { answer => 1 }, { answer => 3 } ], 'perlcode fix with reject';
+}
+
+done_testing;

--- a/t/script.pl
+++ b/t/script.pl
@@ -1,0 +1,11 @@
+use Catmandu::Fix;
+
+sub {
+    my ($data, $reject) = @_;
+    if ($data->{answer} == 2) {
+        return $reject;
+    } else {
+        $data->{answer} ||= 42;
+        return $data;
+    }
+}


### PR DESCRIPTION
This allows to better include arbitrary Perl scripts in fix scripts, e.g.

    if any_match(field,'foo')
      perlcode('postprocessing.pl')
    end