### PR TITLE
Extend help command with information from Pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Catmandu
 
 {{$NEXT}}
+  - help command now shows importer/exporter options
+  - new utility function pod_section 
 
 0.9301  2015-02-24 11:17:36 CET
   - Cmd output test failed sometimes

--- a/lib/Catmandu/Cmd/help.pm
+++ b/lib/Catmandu/Cmd/help.pm
@@ -1,0 +1,64 @@
+package Catmandu::Cmd::help;
+
+use Catmandu::Sane;
+use parent 'Catmandu::Cmd';
+use App::Cmd::Command::help;
+use Catmandu::Util qw(require_package pod_section);
+
+sub description { 'show help' }
+
+sub usage_desc { '%c help [ command | exporter X | importer Y ]' }
+
+sub command_names { qw/help --help -h -?/ }
+
+
+sub execute {
+  my ($self, $opts, $args) = @_;
+
+  if ( @$args == 2 ) {
+    # detect many forms such as:
+    # export JSON, exporter JSON, JSON export, JSON exporter
+    foreach my $type (qw(export import)) {
+      foreach my $index (0,1) {
+        if ( $args->[$index] =~ /^$type(er)?$/i ) {
+          $self->help_about($type, $args->[ ($index+1) % 2]);
+          return;
+        }
+      }
+    }
+  } 
+  
+  App::Cmd::Command::help::execute(@_);
+}
+
+sub help_about {
+  my ($self, $type, $name) = @_;
+
+  my $class = "Catmandu::".ucfirst($type)."er::$name";
+  require_package($class);
+
+  # Show importer/exporter options
+  my $pod = pod_section($class,"configuration");
+
+  $pod =~ s/^([a-z0-9_-]+)\s*\n/--$1, /mgi;
+  $pod =~ s/^(--.*),(\s*[^-])/ $1\n$2/mgi;
+
+  my $about = pod_section($class,"name");
+
+  if ($type eq 'export') {
+    say "catmandu convert ... to $name [options]\n";
+  } else { 
+    say "catmandu convert $name [options] ...\n";
+  }
+  print "$about";
+  print "\n$pod" if $pod;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Catmandu::Cmd::help - show help
+
+=cut 

--- a/lib/Catmandu/Cmd/help.pm
+++ b/lib/Catmandu/Cmd/help.pm
@@ -7,51 +7,86 @@ use Catmandu::Util qw(require_package pod_section);
 
 sub description { 'show help' }
 
-sub usage_desc { '%c help [ command | exporter X | importer Y ]' }
+sub usage_desc { '%c help [ <command> | ( export | import | store | fix ) <name> ]' }
 
 sub command_names { qw/help --help -h -?/ }
 
+my %MODULES = (
+    Exporter => {
+        re => qr/^export(er)?$/i,
+        usage => [ 
+            "catmandu convert ... to %n [options]",
+            "catmandu export  ... to %n [options]",
+        ],
+    },
+    Importer => {
+        re => qr/^import(er)?$/i,
+        usage => [ 
+            "catmandu convert %n [options] to ...",
+            "catmandu import  %n [options] to ...",
+        ],
+    },
+    Store => {
+        re => qr/^(store|move)$/i,
+        usage => [
+            "catmandu import ... to %n [options]",
+            "catmandu move   ... to %n [options]",
+            "catmandu export %n [options] ...",
+            "catmandu move   %n [options] ...",
+        ]
+    },
+    Fix => {
+        re => qr/^fix$/i,
+        usage => [ "%n( [options] )" ]
+    },
+);
 
 sub execute {
-  my ($self, $opts, $args) = @_;
+    my ($self, $opts, $args) = @_;
 
-  if ( @$args == 2 ) {
-    # detect many forms such as:
-    # export JSON, exporter JSON, JSON export, JSON exporter
-    foreach my $type (qw(export import)) {
-      foreach my $index (0,1) {
-        if ( $args->[$index] =~ /^$type(er)?$/i ) {
-          $self->help_about($type, $args->[ ($index+1) % 2]);
-          return;
+    # TODO: list available Importer/Exporters/Stores/Fixes...
+
+    if ( @$args == 2 ) {
+        # detect many forms such as:
+        # export JSON, exporter JSON, JSON export, JSON exporter
+        foreach (0,1) {
+            foreach my $type (keys %MODULES) {
+                if ($args->[$_] =~ $MODULES{$type}->{re}) {
+                    $self->help_about($type, $args->[ ($_+1) % 2 ]);
+                    return;
+                }
+            }
         }
-      }
-    }
-  } 
+    } 
   
-  App::Cmd::Command::help::execute(@_);
+    App::Cmd::Command::help::execute(@_);
 }
 
 sub help_about {
   my ($self, $type, $name) = @_;
 
-  my $class = "Catmandu::".ucfirst($type)."er::$name";
+  my $class = "Catmandu::${type}::$name";
   require_package($class);
 
-  # Show importer/exporter options
-  my $pod = pod_section($class,"configuration");
-
-  $pod =~ s/^([a-z0-9_-]+)\s*\n/--$1, /mgi;
-  $pod =~ s/^(--.*),(\s*[^-])/ $1\n$2/mgi;
-
   my $about = pod_section($class,"name");
+  $about =~ s/\n/ /mg;
+  say ucfirst($about);
 
-  if ($type eq 'export') {
-    say "catmandu convert ... to $name [options]\n";
-  } else { 
-    say "catmandu convert $name [options] ...\n";
+  say "\nUsage:";
+  print join "", map { s/%n/$name/g; "  $_\n" } @{$MODULES{$type}->{usage}};
+
+  my $descr = pod_section($class,"description");
+  chomp $descr;
+  say "\n$descr" if $descr;
+  
+  # TODO: include examples?
+
+  my $options = pod_section($class,"configuration");
+  if ($options) {
+    $options =~ s/^([a-z0-9_-]+)\s*\n?/--$1, /mgi;
+    $options =~ s/^(--.*),(\s*([^-]))/ $1\n    $3/mgi;
+    print "\nOptions:\n$options";
   }
-  print "$about";
-  print "\n$pod" if $pod;
 }
 
 1;

--- a/lib/Catmandu/Cmd/help.pm
+++ b/lib/Catmandu/Cmd/help.pm
@@ -84,7 +84,7 @@ sub help_about {
   my $options = pod_section($class,"configuration");
   if ($options) {
     $options =~ s/^([a-z0-9_-]+)\s*\n?/--$1, /mgi;
-    $options =~ s/^(--.*),(\s*([^-]))/ $1\n    $3/mgi;
+    $options =~ s/^(--[a-z0-9_-]+(,\s*--[a-z0-9_-]+)*),\s*([^-])/" $1\n    $3"/emgi;
     print "\nOptions:\n$options";
   }
 }

--- a/lib/Catmandu/Exporter/CSV.pm
+++ b/lib/Catmandu/Exporter/CSV.pm
@@ -68,6 +68,9 @@ sub add {
     $self->csv->print($fh, $row);
 }
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Exporter::CSV - a CSV exporter
@@ -105,15 +108,25 @@ are in field values are escaped as C<\n>, C<\r>, and C<\t>.
 
 =head1 CONFIGURATION
 
-=over 4
+=over
+
+=item file
+
+=item fh
+
+=item fix
+
+=item encoding
+
+Default options of L<Catmandu::Exporter>
 
 =item sep_char
 
-Column separator (C<,> by default>)
+Column separator (C<,> by default)
 
 =item quote_char
 
-Quotation character (C<"> by default>)
+Quotation character (C<"> by default)
 
 =item escape_char
 
@@ -127,7 +140,7 @@ string, or hash reference.
 =item header
 
 Include a header line with the column names, if set to C<1> (the default).
-Custom field names can be supplied as has reference. By default field names
+Custom field names can be supplied as hash reference. By default field names
 are used as as column names.
 
 =back
@@ -139,8 +152,7 @@ L<Catmandu::Counter>, and L<Catmandu::Logger> for a full list of methods.
 
 =head1 SEE ALSO
 
-L<Catmandu::Exporter::Table>
+L<Catmandu::Importer::CSV>, L<Catmandu::Exporter::Table>
+L<Catmandu::Exporter::XLS>
 
 =cut
-
-1;

--- a/lib/Catmandu/Exporter/JSON.pm
+++ b/lib/Catmandu/Exporter/JSON.pm
@@ -104,13 +104,13 @@ each item is printed condensed on one line.
 
 =item encoding
 
-Default options of L<Catmandu::Exporter>.
+Default options of L<Catmandu::Exporter>
 
 =item pretty
 
 =item multiline
 
-Alias for C<pretty>.
+Pretty-print JSON
 
 =item indent
 
@@ -120,11 +120,11 @@ Alias for C<pretty>.
 
 =item canonical
 
-L<JSON> serialization options.
+L<JSON> serialization options
 
 =item array
 
-Seralize items as one JSON array instead of concatenated JSON objects.
+Seralize items as one JSON array instead of concatenated JSON objects
 
 =back
 

--- a/lib/Catmandu/Exporter/Null.pm
+++ b/lib/Catmandu/Exporter/Null.pm
@@ -8,6 +8,9 @@ with 'Catmandu::Exporter';
 
 sub add {}
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Exporter::Null - a expoter that doesn't export anything
@@ -17,18 +20,25 @@ Catmandu::Exporter::Null - a expoter that doesn't export anything
   	# From the commandline
   	$ catmandu convert JSON --fix myfixes to Null < /tmp/data.json
 
-
 =head1 DESCRIPTION
 
 This exporter exports nothing and can be used as in situations where you e.g. export
 data from a fix.
 
+=head1 CONFIGURATION
+
+=item file
+
+=item fh
+
+=item fix
+
+=item encoding
+
+Default options of L<Catmandu::Exporter>
+
 =head1 SEE ALSO
 
-L<Catmandu::Exporter>
+L<Catmandu::Importer::Mock>
 
 =cut
-
-
-1;
-

--- a/lib/Catmandu/Exporter/YAML.pm
+++ b/lib/Catmandu/Exporter/YAML.pm
@@ -15,6 +15,9 @@ sub add {
     $self->fh->print("...\n");
 }
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Exporter::YAML - a YAML exporter
@@ -38,10 +41,20 @@ Catmandu::Exporter::YAML - a YAML exporter
 
     printf "exported %d objects\n" , $exporter->count;
 
+=head1 CONFIGURATION
+
+=item file
+
+=item fh
+
+=item fix
+
+=item encoding
+
+Default options of L<Catmandu::Exporter>
+
 =head1 SEE ALSO
 
 L<Catmandu::Exporter>
 
 =cut
-
-1;

--- a/lib/Catmandu/Importer/CSV.pm
+++ b/lib/Catmandu/Importer/CSV.pm
@@ -55,6 +55,9 @@ sub generator {
     };
 }
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Importer::CSV - Package that imports CSV data
@@ -75,35 +78,70 @@ Convert CSV to other formats with the catmandu command line client:
     # convert CSV file to JSON
     catmandu convert CSV to JSON < journals.csv
     # set column names if CSV file has no header line
-    echo '12157,"The Journal of Headache and Pain",2193-1801' | catmandu convert CSV --header 0 --fields 'id,title,issn' to YAML
+    echo '12157,"The Journal of Headache and Pain",2193-1801' | \
+      catmandu convert CSV --header 0 --fields 'id,title,issn' to YAML
     # set field separator and quote character 
-    echo '12157;$The Journal of Headache and Pain$;2193-1801' | catmandu convert CSV --header 0 --fields 'id,title,issn' --sep_char ';' --quote_char '$' to XLSX --file journal.xlsx
+    echo '12157;$The Journal of Headache and Pain$;2193-1801' | \
+      catmandu convert CSV --header 0 --fields 'id,title,issn' --sep_char ';' --quote_char '$' to XLSX --file journal.xlsx
+
+=head1 DESCRIPTION
+
+This L<Catmandu::Importer> imports comma-separated values (CSV).  The object
+fields are read from the CSV header line or given via the C<fields> parameter.
+Strings in CSV are quoted by C<quote_char> and fields are separated by
+C<sep_char>.
+
+=head1 CONFIGURATION
+
+=over
+
+=item file
+
+=item fh
+
+=item encoding
+
+=item fix
+
+Default options of L<Catmandu::Importer>
+
+=item fields
+
+List of fields to be used as columns, given as array reference, comma-separated
+string, or hash reference.
+
+=item header
+
+Read fields from a header line with the column names, if set to C<1> (the
+default).
+
+=item sep_char
+
+Column separator (C<,> by default)
+
+=item quote_char
+
+Quotation character (C<"> by default)
+
+=item escape_char
+
+Character for escaping inside quoted field (C<"> by default)
+
+=item allow_loose_quotes
+
+=item allow_loose_escapes
+
+Allow common bad-practice in CSV escaping
+
+=back
 
 =head1 METHODS
 
-=head2 new(file => $filename, fh = $fh, fields => \@fields, quote_char => "\"", sep_char => ",", fix => [...])
-
-Create a new CSV importer for $filename. Use STDIN when no filename is given. The
-object fields are read from the CSV header line or given via the 'fields' parameter.
-Strings in CSV are quoted by 'quote_char' and fields are separated by 'sep_char'.
-
-The constructor inherits the fix parameter from L<Catmandu::Fixable>. When given,
-then ech fix or fix script will be applied to imported items.
-
-=head2 count
-
-=head2 each(&callback)
-
-=head2 ...
-
 Every L<Catmandu::Importer> is a L<Catmandu::Iterable> all its methods are
-inherited. The Catmandu::Importer::CSV methods are not idempotent: CSV streams
-can only be read once.
+inherited.  The methods are not idempotent: CSV streams can only be read once.
 
 =head1 SEE ALSO
 
-L<Catmandu::Iterable>
+L<Catmandu::Exporter::CSV>, L<Catmandu::Importer::XLS>
 
 =cut
-
-1;

--- a/lib/Catmandu/Importer/JSON.pm
+++ b/lib/Catmandu/Importer/JSON.pm
@@ -58,6 +58,9 @@ sub generator {
     };
 }
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Importer::JSON - Package that imports JSON data
@@ -82,31 +85,35 @@ The defaults assume a newline delimited JSON file:
 Use the C<multiline> or C<array> options to parse pretty-printed JSON or JSON
 arrays.
 
+=head1 CONFIGURATION
+
+=over
+
+=item file
+
+=item fh
+
+=item encoding
+
+=item fix
+
+Default options of L<Catmandu::Importer>
+
+=item multiline
+
+=item array
+
+Read JSON with line-breaks or a JSON array instead of line-delimited JSON
+
+=back
+
 =head1 METHODS
 
-=head2 new(file => $filename , fh => $fh , multiline => 0|1 ,fix => [...])
-
-Create a new JSON importer for C<$filename>. Uses STDIN when no filename is given.
-C<multiline> switches optionally between line-delimited JSON and multiline JSON or arrays.
-the default is line-delimited JSON.
-
-The constructor inherits the fix parameter from L<Catmandu::Fixable>. When given,
-then each fix or fix script will be applied to imported items.
-
-=head2 count
-
-=head2 each(&callback)
-
-=head2 ...
-
 Every L<Catmandu::Importer> is a L<Catmandu::Iterable> all its methods are
-inherited. The Catmandu::Importer::JSON methods are not idempotent: JSON
-streams can only be read once.
+inherited. The methods are not idempotent: JSON streams can only be read once.
 
 =head1 SEE ALSO
 
-L<Catmandu::Iterable>
+L<Catmandu::Exporter::JSON>
 
 =cut
-
-1;

--- a/lib/Catmandu/Importer/Mock.pm
+++ b/lib/Catmandu/Importer/Mock.pm
@@ -17,6 +17,9 @@ sub generator {
     };
 }
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Importer::Mock - Mock importer used for testing purposes
@@ -32,28 +35,33 @@ Catmandu::Importer::Mock - Mock importer used for testing purposes
         # ...
     });
 
+=head1 CONFIGURATION
+
+=over
+
+=item file
+
+=item fh
+
+=item encoding
+
+=item fix
+
+Default options of L<Catmandu::Importer>
+
+=item size
+
+Number of items. If not set, an endless stream is imported.
+
+=back
+
 =head1 METHODS
-
-=head2 new(size => $n, fix => [...])
-
-Create a new Mock importer. Optionally provide a size parameter.
-
-The constructor inherits the fix parameter from L<Catmandu::Fixable>. When given,
-then each fix or fix script will be applied to imported items.
-
-=head2 count
-
-=head2 each(&callback)
-
-=head2 ...
 
 Every L<Catmandu::Importer> is a L<Catmandu::Iterable> all its methods are
 inherited.
 
 =head1 SEE ALSO
 
-L<Catmandu::Iterable>
+L<Catmandu::Exporter::Null>
 
 =cut
-
-1;

--- a/lib/Catmandu/Importer/Modules.pm
+++ b/lib/Catmandu/Importer/Modules.pm
@@ -82,7 +82,7 @@ sub generator {
 
 Catmandu::Importer::Modules - list installed perl modules in a given namespace
 
-=head1 OPTIONS
+=head1 CONFIGURATION
 
 =over
 

--- a/lib/Catmandu/Importer/Modules.pm
+++ b/lib/Catmandu/Importer/Modules.pm
@@ -78,6 +78,9 @@ sub generator {
     };
 }
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Importer::Modules - list installed perl modules in a given namespace
@@ -86,26 +89,43 @@ Catmandu::Importer::Modules - list installed perl modules in a given namespace
 
 =over
 
+=item file
+
+=item fh
+
+=item encoding
+
+=item fix
+
+Default options of L<Catmandu::Importer>
+
 =item namespace
 
-namespace for the packages to list
+Namespace for the packages to list
 
 =item inc
 
-list of library paths (defaults to C<@INC>)
+List of library paths (defaults to C<@INC>)
 
 =item max_depth
 
-maximum depth to recurse into the namespace e.g. if the namespace is
+Maximum depth to recurse into the namespace e.g. if the namespace is
 Catmandu::Fix then Catmandu::Fix::add_field has a depth of 1 and
 Catmandu::Fix::Condition::exists a depth of 2
 
 =item pattern
 
-filter modules by the given regex pattern
+Filter modules by the given regex pattern
 
 =back
 
-=cut
+=head1 METHODS
 
-1;
+Every L<Catmandu::Importer> is a L<Catmandu::Iterable> all its methods are
+inherited.
+
+=head1 SEE ALSO
+
+L<Catmandu::Importer::CPAN>, L<Catmandu::Cmd::info>
+
+=cut

--- a/lib/Catmandu/Importer/YAML.pm
+++ b/lib/Catmandu/Importer/YAML.pm
@@ -40,6 +40,9 @@ sub generator {
     };
 }
 
+1;
+__END__
+
 =head1 NAME
 
 Catmandu::Importer::YAML - Package that imports YAML data
@@ -67,20 +70,25 @@ Catmandu::Importer::YAML - Package that imports YAML data
 
     where '---' is the record separator and '...' the EOF indicator.
 
+=head1 CONFIGURATION
+
+=over
+
+=item file
+
+=item fh
+
+=item encoding
+
+=item fix
+
+Default options of L<Catmandu::Importer>
+
+=item
+
+=back
+
 =head1 METHODS
-
-=head2 new(file => $filename, fh => $fh , fix => [...])
-
-Create a new YAML importer for $filename. Use STDIN when no filename is given.
-
-The constructor inherits the fix parameter from L<Catmandu::Fixable>. When given,
-then any fix or fix script will be applied to imported items.
-
-=head2 count
-
-=head2 each(&callback)
-
-=head2 ...
 
 Every L<Catmandu::Importer> is a L<Catmandu::Iterable> all its methods are
 inherited. The Catmandu::Importer::YAML methods are not idempotent: YAML feeds
@@ -88,8 +96,6 @@ can only be read once.
 
 =head1 SEE ALSO
 
-L<Catmandu::Iterable>
+L<Catmandu::Exporter::YAML>
 
 =cut
-
-1;

--- a/lib/Catmandu/Util.pm
+++ b/lib/Catmandu/Util.pm
@@ -520,12 +520,14 @@ sub pod_section {
     my $class = ref $_[0] ? ref(shift) : shift;
     my $section = uc(shift);
 
-    (my $pm_file = $class) =~ s!::!/!g;
-    $pm_file .= '.pm';
-    $pm_file = $INC{$pm_file} or return '';
+    unless (-r $class) {
+        $class =~ s!::!/!g;
+        $class .= '.pm';
+        $class = $INC{$class} or return '';
+    }
 
     my $text = "";
-    open my $input, "<", $pm_file or return '';
+    open my $input, "<", $class or return '';
     open my $output, ">", \$text;
 
     require Pod::Usage; # lazy load only if needed
@@ -1096,7 +1098,7 @@ Add directories to C<@INC> at runtime.
 
 Throws a Catmandu::Error on failure.
 
-=item pod_section($package, $section [, @options] )
+=item pod_section($package_or_file, $section [, @options] )
 
 Get documentation of a package for a selected section. Additional options are
 passed to L<Pod::Usage>.


### PR DESCRIPTION
This pull request extends the help command to show information from Pod sections NAME, DESCRIPTION and CONFIGURATION for requested Importers, Exporters, Stores, and fixes.

See #145 for the feature request.