### PR TITLE
Add doc comment drawing attention to verbose flag

### DIFF
--- a/bin/catmandu
+++ b/bin/catmandu
@@ -143,7 +143,7 @@ Low level data manipulation command. See DATA OPTIONS below for full documentati
 
 =item -v
 
-Verbose output.
+Verbose output. Includes progress of operations.
 
 =item -h
 


### PR DESCRIPTION
For some reason I completely missed the verbose flag. Having the word 'progress' would have helped me find it - maybe someone else will find it useful too?