### PR TITLE
Introduce .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+Christian Pietsch <chr.pietsch+cpan@gmail.com>
+Dave Sherohman <dsheroh@cpan.org> <Dave.Sherohman@lub.lu.se>
+Dave Sherohman <dsheroh@cpan.org> <Dave.Sherohman@ub.lu.se>
+Jakob Voß <jakob.voss@gbv.de> <jakob@nichtich.de>
+Jakob Voß <jakob.voss@gbv.de> <voss@gbv.de>
+Johann Rolschewski <jorol@cpan.org> <rolschewski@gmail.com>
+Magnus Enger <magnus@enger.priv.no>
+Nicolas Franck <njfranck@cpan.org> <nicolas.franck@ugent.be>
+Nicolas Franck <njfranck@cpan.org> <njfranck@ca20c521.ugent.be>
+Nicolas Steenlant <nicolas.steenlant@ugent.be> <nicolas.steenlant@gmail.com>
+Nicolas Steenlant <nicolas.steenlant@ugent.be> <nsteenla@ca20c608.ugent.be>
+Nicolas Steenlant <nicolas.steenlant@ugent.be> <nicolas.steenlant@ugent.be>
+Patrick Hochstenbach <patrick.hochstenbach@gmail.com> <patrick.hochstenbach@ugent.be>
+Patrick Hochstenbach <patrick.hochstenbach@gmail.com> <phochste@hal.lub.lu.se>
+Patrick Hochstenbach <patrick.hochstenbach@gmail.com> <phochste@vmtemp4.ugent.be>
+Snorri Briem <Snorri.Briem@lub.lu.se> <Snorri.Briem@ub.lu.se>
+Upasana Shukla <me@upasana.me>
+Vitali Peil <vpeil@cpan.org> <vitali.peil@uni-bielefeld.de>

--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,5 @@
 name = Catmandu
+author = Nicolas Steenlant <nicolas.steenlant@ugent.be>
 [@Milla]
 installer = ModuleBuild
 [ExecDir]


### PR DESCRIPTION
The mapping of author nameis and email addresses to canonical form
facilitates blaming people (e.g. `git shortlog -sne`) and gives a clean
META.json. The primary email is the address used at CPAN so metacpan.org
links contributors to their author page.