### PR TITLE
return full response from underlying commit method

### DIFF
--- a/lib/Catmandu/Addable.pm
+++ b/lib/Catmandu/Addable.pm
@@ -25,9 +25,9 @@ around add => sub {
 
 around commit => sub {
     my ($orig, $self) = @_;
-    my $res = $orig->($self);
+    my(@res) = $orig->($self);
     $self->_commit(1);
-    $res;
+    @res;
 };
 
 sub add_many {


### PR DESCRIPTION
The commit method in Catmandu::Store::Solr::Bag is now broken with Catmandu 0.9504.
The reason for this is the "around" modifier in Catmandu::Addable that only expects one return value
