### PR TITLE
GH#213: Support escape characters in CSV import options

### DIFF
--- a/lib/Catmandu/Importer/CSV.pm
+++ b/lib/Catmandu/Importer/CSV.pm
@@ -12,7 +12,15 @@ use namespace::clean;
 with 'Catmandu::Importer';
 
 has csv => (is => 'ro', lazy => 1, builder => '_build_csv');
-has sep_char => (is => 'ro', default => sub { ',' });
+has sep_char => (
+    is      => 'ro',
+    default => sub {','},
+    coerce  => sub {
+        my $sep_char = $_[0];
+        $sep_char =~ s/(\\[abefnrt])/"qq{$1}"/gee;
+        return $sep_char;
+    }
+);
 has quote_char => (is => 'ro', default => sub { '"' });
 has escape_char => (is => 'ro', default => sub { '"' });
 has allow_loose_quotes => (is => 'ro', default => sub { 0 });

--- a/t/Catmandu-Importer-CSV.t
+++ b/t/Catmandu-Importer-CSV.t
@@ -43,5 +43,18 @@ $importer = $pkg->new(file => \$csv, header => 0);
 
 is_deeply $importer->to_array, $data;
 
+$data = [
+   {name=>'Nicolas',age=>'34'},
+];
+
+$csv = <<EOF;
+"name"	"age"
+"Nicolas"	"34"
+EOF
+
+$importer = $pkg->new(file => \$csv, sep_char => '\t');
+
+is_deeply $importer->to_array, $data;
+
 done_testing;
 


### PR DESCRIPTION
see #213.

Added support for [character escapes](http://perldoc.perl.org/perlrebackslash.html#Character-Escapes) for parameter `sep_char` to Catmandu-Importer-CSV and added a test.

Test `Catmandu-Importer-CSV.t` passed, but [Travis Build](https://travis-ci.org/jorol/Catmandu/jobs/103593710) failed for other reasons.

