### PR TITLE
add transaction method to Store::Hash for usage within unit testing

### DIFF
--- a/lib/Catmandu/Store/Hash.pm
+++ b/lib/Catmandu/Store/Hash.pm
@@ -11,6 +11,7 @@ use namespace::clean;
 
 with 'Catmandu::Store';
 with 'Catmandu::Droppable';
+with 'Catmandu::Transactional';
 
 has _hashes   => (is => 'ro' , lazy => 1, init_arg => undef, default => sub { +{} });
 has init_data => (is => 'ro');
@@ -26,6 +27,11 @@ sub drop {
     my ($self) = @_;
     $_->drop for values %{$self->bags};
     return;
+}
+
+sub transaction {
+    my ($self, $coderef) = @_;
+    &{$coderef} if is_code_ref($coderef);
 }
 
 1;
@@ -73,13 +79,13 @@ for fast retrieval combined with a doubly linked list for fast traversal.
 Create a new Catmandu::Store::Hash. Optionally provide as init_data an array
 ref of data:
 
-    my $store = Catmandu->store('Hash', init_data => [ 
+    my $store = Catmandu->store('Hash', init_data => [
            { _id => 1, data => foo } ,
            { _id => 2, data => bar }
     ]);
 
     # or in a catmandu.yml configuration file:
-    
+
     ---
     store:
        hash:


### PR DESCRIPTION
I need for unit testing the transaction method ( in my testing environment I'm gonna use Store:Hash instead of a "real" store). So maybe it's safe to add this non-method to a non-store ( as discussed earlier we won't do this in general if there's no real transaction operation. Any objections, @nics ?