### PR TITLE
Started to include Glossary

### DIFF
--- a/lib/Catmandu/Cmd/count.pm
+++ b/lib/Catmandu/Cmd/count.pm
@@ -6,7 +6,6 @@ our $VERSION = '1.0002';
 
 use parent 'Catmandu::Cmd';
 use Catmandu;
-use Catmandu::Fix;
 use namespace::clean;
 
 sub command_opt_spec {

--- a/lib/Catmandu/Cmd/data.pm
+++ b/lib/Catmandu/Cmd/data.pm
@@ -5,8 +5,7 @@ use Catmandu::Sane;
 our $VERSION = '1.0002';
 
 use parent 'Catmandu::Cmd';
-use Catmandu qw(:all);
-use Catmandu::Fix;
+use Catmandu;
 use namespace::clean;
 
 sub command_opt_spec {
@@ -48,9 +47,9 @@ sub command {
     my $into;
 
     if ($opts->from_bag) {
-        $from = store($opts->from_store, $from_opts)->bag($opts->from_bag);
+        $from = Catmandu->store($opts->from_store, $from_opts)->bag($opts->from_bag);
     } else {
-        $from = importer($opts->from_importer, $from_opts);
+        $from = Catmandu->importer($opts->from_importer, $from_opts);
     }
 
     if ($opts->query || $opts->cql_query) {
@@ -74,13 +73,13 @@ sub command {
     }
 
     if ($opts->into_bag) {
-        $into = store($opts->into_store, $into_opts)->bag($opts->into_bag);
+        $into = Catmandu->store($opts->into_store, $into_opts)->bag($opts->into_bag);
     } else {
-        $into = exporter($opts->into_exporter, $into_opts);
+        $into = Catmandu->exporter($opts->into_exporter, $into_opts);
     }
 
     if (my $fix = $opts->fix) {
-        $from = Catmandu::Fix->new(fixes => $fix)->fix($from);
+        $from = Catmandu->fixer($fix)->fix($from);
     }
 
     if ($opts->replace && $into->can('delete_all')) {

--- a/lib/Catmandu/Cmd/help.pm
+++ b/lib/Catmandu/Cmd/help.pm
@@ -59,6 +59,13 @@ sub execute {
                 }
             }
         }
+    } elsif ( @$args == 1 ) {
+        my $term = $args->[0];
+        require_package('Catmandu::Help::Glossary');
+        if ( $term =~ /^glossary|terms$/i ) {
+            say pod_section('Catmandu::Help::Glossary', 'GLOSSARY');
+            return;
+        }
     } 
   
     App::Cmd::Command::help::execute(@_);

--- a/lib/Catmandu/Cmd/info.pm
+++ b/lib/Catmandu/Cmd/info.pm
@@ -5,8 +5,7 @@ use Catmandu::Sane;
 our $VERSION = '1.0002';
 
 use parent 'Catmandu::Cmd';
-use Catmandu::Importer::Modules;
-use Catmandu::Store::Hash;
+use Catmandu;
 use Catmandu::Util qw(pod_section);
 use namespace::clean;
 
@@ -74,7 +73,7 @@ sub command {
         $from_opts->{$key} = $opts->$key if defined $opts->$key;
     }
 
-    my $from = Catmandu::Importer::Modules->new($from_opts);
+    my $from = Catmandu->importer('Modules',$from_opts);
 
     my $into_args = [];
     my $into_opts = {};

--- a/lib/Catmandu/Cmd/run.pm
+++ b/lib/Catmandu/Cmd/run.pm
@@ -6,8 +6,7 @@ our $VERSION = '1.0002';
 
 use parent 'Catmandu::Cmd';
 use Catmandu;
-use Catmandu::Interactive;
-use Catmandu::Fix;
+use Catmandu::Util qw(require_package);
 use namespace::clean;
 
 sub command_opt_spec {
@@ -21,6 +20,7 @@ sub command {
     my ($self, $opts, $args) = @_;
 
     if (defined $opts->{i} || !defined $args->[0]) {
+        my $pkg = require_package('Catmandu::Interactive');
         my $app = Catmandu::Interactive->new();
         $app->run();
     }

--- a/lib/Catmandu/Help/Binds.pm
+++ b/lib/Catmandu/Help/Binds.pm
@@ -1,0 +1,83 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Binds
+
+B<Binds> change the execution context of a Fix script. In normal operation, all
+Fix functions are executed from the first to the last. For example given the YAML
+input:
+
+    ---
+    colors:
+      - red
+      - green
+      - blue
+
+every Fix functions will be executed one by one on all the colors:
+
+    upcase(colors.*)
+    append(colors.*," is a nice color")
+    copy_field(colors.*,result.$append)
+
+The first Fix C<upcase> will uppercase all the colors, the second C<append> will
+add " is a nice color" to all the colors, the last C<copy_field> will copy all the
+colors to a new field.
+
+But what should you do when you want the three Fix functions to operate on each
+color separately? First upcase on the first color, append on the first color,
+copy_field on the first color, then again upcase on the second color, append on
+the second color, etc.
+
+For this type of operation a Bind is needed using the C<do notation>:
+
+    do list(path:colors.*, var:c)
+      upcase(c)
+      append(c," is a nice color")
+      copy_field(c,result.$append)
+    end
+
+In the example above the list Bind was introduced. The context of the execution of
+the Bind body is changed. Instead of operating on one Catmandu item as a whole,
+the Fix functions are executed for each element in the list.
+
+Each Bind changes the execution context in some way. For instance Fix functions
+could execute queries into database, or fetch data from the internet. These operations
+can fail when the database is down, or the website couldn't be reached. What should
+happen in that case in a Fix script? Should the execution be stopped? Or, should
+there errors be ignored.
+
+    my_fix1()
+    my_fix2()
+    download_from_internet() # <--- this one failes
+    process_results()
+
+What should happen in the example above? Should the results be processed when the
+download_from_internet fails? Using the B<maybe> Bind one can skip Fix functions that fail:
+
+    do maybe()
+      my_fix1()
+      my_fix2()
+      download_from_internet()
+      process_results() # <--- this is skipped when download_from_internet fails
+    end
+
+Binds are also used when creating Fix executables. That are Fix scripts that can be
+run directly from the command line. In the example below we'll write a Fix script
+that downloads data from an OAI-PMH repository and prints all the record identifiers:
+
+    #!/usr/bin/env catmandu run
+    do importer(OAI,url: "http://lib.ugent.be/oai")
+      retain(_id)
+      add_to_exporter(.,YAML)
+    end
+
+If this script is stored on a file system as myscript.fix and made executable:
+
+    $ chmod 755 myscript.fix
+
+then you can run this script as any other Unix command:
+
+    $ ./myscript.fix

--- a/lib/Catmandu/Help/CheatSheet.pm
+++ b/lib/Catmandu/Help/CheatSheet.pm
@@ -1,0 +1,139 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Fixes Cheat Sheet
+
+This page provides an overview of the Fix language. Fixes clean your data. Every
+fix gets as input an item (a Perl HASH) and transforms it with the function and
+parameters given.
+
+=head1 Simple fixes to add a field or set its value
+
+  set_field(my.name,patrick)         # { my => { name  => 'patrick'} }
+  add_field(my.name2,nicolas)        # { my => { name2 => 'nicolas'} }
+
+  set_array(foo)                     # { foo => [] }
+  set_array(foo,a,b,c)               # { foo => ['a','b','c'] }
+
+  set_hash(foo)                      # { foo => {} }
+  set_hash(foo,a: b,c: d)            # { foo => { a => 'b', b => 'd' }}
+
+=head1 Copy, move, delete fields
+
+  move_field("my.name","your.name")    # { your => { name => 'patrick'} }
+  copy_field("your.name","your.name2") # { your => { name => 'patrick' , name2 => 'patrick'} }
+  remove_field("your.name")            # { your => { name => 'patrick'} }
+
+  # Delete every field, except 'id' , 'name' and 'your.name'
+  retain("id","name")
+
+=head1 Transform arrays to hashes, hashes to arrays
+
+  # Create an array from a hash
+  array("foo")                         # foo => {"name":"value"} => [ "name" , "value" ]
+
+  # Create a hash from an array
+  hash("foo")                          # foo => [ "name" , "value" ] => {"name":"value" }
+
+  # Associate two values as a hash key and value
+  assoc(fields, pairs.*.key, pairs.*.val) # {pairs => [{key => 'year', val => 2009}, {key => 'subject', val => 'Perl'}]}
+                                          # {fields => {subject => 'Perl', year => 2009}, pairs => [...]}
+
+=head1 Manipulate text and numbers
+
+  upcase("title")                            # marc -> MARC
+  downcase("title")                          # MARC -> marc
+  capitalize("my.deeply.nested.field.0")     # marc -> Marc
+  trim("field_with_spaces")                  # "  marc  " -> marc
+  substring("title",0,1)                     # marc -> m
+  prepend("title","die ")                    # marc -> die marc
+  append("title"," must die")                # marc -> marc must die
+
+  split_field("foo",":")                     # marc:must:die -> ['marc','must','die']
+  join_field("foo",":")                      # ['marc','must','die'] -> marc:must:die
+  retain("id","id2","id3")                   # delete any field except 'id', 'id2', 'id3'
+  replace_all("title","a","x")               # marc -> mxrc
+
+  # Most functions can work also work on arrays. E.g.
+  replace_all("author.*","a","x")            # [ 'marc','jan'] => ['mxrc','jxn']
+  # Use:
+  #   authors.$end (last entry)
+  #   authors.$start (first entry)
+  #   authors.$append (last + 1)
+  #   authors.$prepend (first - 1)
+  #   authors.* (all authors)
+  #   authors.2 (3rd author)
+
+  count("myarray")                           # count number of elements in an array or hash
+  sum("numbers")                             # replace an array element with the sum of its values
+  sort_field("tags")                         # sort the values of an array
+  sort_field("tags", uniq:1)                 # sort the values plus keep unique values
+  sort_field("tags", reverse:1)              # revese sort
+  sort_field("tags", numeric:1)              # sort numerical values
+  uniq(tags)                                 # strip duplicate values from an array
+  filter("tags","[Cc]at")                    # filter array values tags = ["Cats","Dogs"] => ["Cats"]
+  flatten(deep)                              # {deep => [1, [2, 3], 4, [5, [6, 7]]]} => {deep => [1, 2, 3, 4, 5, 6, 7]}
+
+  # {author => "tom jones"}  -> {author => "senoj mot"}
+  reverse(author)
+
+  # {numbers => [1,14,2]} -> {numbers => [2,14,1]}
+  reverse(numbers)
+
+  # replace the value with a formatted (sprintf-like) version
+  # e.g. numbers:
+  #         - 41
+  #         - 15
+  format(number,"%-10.10d %-5.5d") # numbers => "0000000041 00015"
+  # e.g. hash:
+  #        name: Albert
+  format(name,"%-10s: %s") # hash: "name      : Albert"
+
+  parse_text(date, '(\d\d\d\d)-(\d\d)-(\d\d)')
+  # date:
+  #    - 2015
+  #    - 03
+  #    - 07
+
+  #  parses a text into an array or hash of values
+  # date: "2015-03-07"
+  parse_text(date, '(\d\d\d\d)-(\d\d)-(\d\d)')
+  # date:
+  #    - 2015
+  #    - 03
+  #    - 07
+
+  # If you data record is:
+  #   a: eeny
+  #   b: meeny
+  #   c: miny
+  #   d: moe
+  paste(my.string,a,b,c,d)                 # my.string: eeny meeny miny moe
+
+  # Use a join character
+  paste(my.string,a,b,c,d,join_char:", ")  # my.string: eeny, meeny, miny, moe
+
+  # Paste literal strings with a tilde sign
+  paste(my.string,~Hi,a,~how are you?)     # my.string: Hi eeny how are you?
+
+  # date: "2015-03-07"
+  parse_text(date, '(?<year>\d\d\d\d)-(?<month>\d\d)-(?<day>\d\d)')
+  # date:
+  #   year: "2015"
+  #   month: "03"
+  #   day: "07"
+
+  # date: "abcd"
+  parse_text(date, '(\d\d\d\d)-(\d\d)-(\d\d)')
+  # date: "abcd"
+
+  # '3%A9' => 'café'
+  uri_decode(place)
+  # 'café' => '3%A9'
+  uri_encode(place)
+
+  # Add a new field 'foo' with a random value between 0 and 9
+  random(foo, 10)

--- a/lib/Catmandu/Help/CheatSheet.pm
+++ b/lib/Catmandu/Help/CheatSheet.pm
@@ -30,6 +30,125 @@ parameters given.
   # Delete every field, except 'id' , 'name' and 'your.name'
   retain("id","name")
 
+=head1 Select,reject records on some conditions
+
+  # Select all records
+  select()
+
+  # Select only records with have 'MARC' in the title
+  select all_match(title,'MARC')
+
+  # Select only the records with have a 'foo' field
+  select exists(foo)
+
+  # Reject all records
+  reject()
+
+  # Reject the records that have a 'foo' field
+  reject exists(foo)
+
+=head1 Conditionals
+
+  # uppercase the value of field 'foo' if all members of 'oogly' have the value 'doogly'
+  if all_match('oogly.*', 'doogly')
+    upcase('foo') # foo => 'BAR'
+  else
+    downcase('foo') # foo => 'bar'
+  end
+
+  # inverted
+  unless all_match('oogly.*', 'doogly')
+    upcase('foo') # foo => 'BAR'
+  end;
+
+  # uppercase the value of field 'foo' if field 'oogly' has the value 'doogly'
+  if any_match('oogly', 'doogly')
+    upcase('foo') # foo => 'BAR'
+  end
+
+  # inverted
+  unless any_match('oogly', 'doogly')
+    upcase('foo') # foo => 'BAR'
+  end
+
+  # uppercase the value of field 'foo' if the field 'oogly' exists
+  if exists('oogly')
+    upcase('foo') # foo => 'BAR'
+  end
+
+  # inverted
+  unless exists('oogly')
+    upcase('foo') # foo => 'bar'
+  end
+
+  # add a new field when the 'year' field is equal to 2018
+  if all_equal('year','2018')
+    add_field('my.funny.title','true')
+  end
+
+  # add a new field when at least one of the 'year'-s is equal to 2018
+  if any_equal('years.*','2018')
+    add_field('my.funny.title','true')
+  end
+
+  # compare things (needs Catmandu 0.92 or better)
+  if greater_than('year',2000)
+    add_field('recent','yes')
+  end
+
+  if less_than('year',1970)
+    add_field('ancient','yes')
+  end
+
+  # execute fixes if one path is contained in another
+  # foo => 1 , bar => [3,2,1]  => in(foo,bar) -> true
+  if in(foo,bar)
+    add_field(test,ok)
+  end
+
+  # only execute fixes if all path values are the boolean true, 1 or "true"
+  if is_true(data.*.has_error)
+    add_field(error,yes)
+  end
+
+  # only execute fixes if all path values are the boolean true, 0 or "false"
+  if is_false(data.*.has_error)
+    add_field(error,no)
+  end
+
+  # only execute the fixes if the path contains an array
+  if is_array(data)
+    upcase(data.0)
+  end
+
+  # only execute the fixes if the path contains an object (an hash, nested field)
+  if is_object(data)
+    add_field(data.ok,yes)
+  end
+
+  # only execute the fixes if the path contains a number
+  if is_number(data)
+    append(data," : is a number")
+  end
+
+  # only execute the fixes if the path contains a string
+  if is_string(data)
+    append(data," : is a string")
+  end
+
+  # only execute the fixes if the path contains 'null' values
+  if is_null(data)
+    set_field(data,"I'm empty!")
+  end
+
+  # Evaludates true when a marc (sub)field matches a regular expression
+  if marc_match('245','My funny title')
+    add_field('funny.title','yes')
+  end
+  if marc_match('LDR/6','c')
+    marc_set('LDR/6','p')
+  end
+
 =head1 Transform arrays to hashes, hashes to arrays
 
   # Create an array from a hash
@@ -47,14 +166,19 @@ parameters given.
   upcase("title")                            # marc -> MARC
   downcase("title")                          # MARC -> marc
   capitalize("my.deeply.nested.field.0")     # marc -> Marc
+  reverse(author)                            # marc -> cram
+  reverse(numbers)                           # [1,2,3] -> [3,2,1]
+
   trim("field_with_spaces")                  # "  marc  " -> marc
+
   substring("title",0,1)                     # marc -> m
+
   prepend("title","die ")                    # marc -> die marc
   append("title"," must die")                # marc -> marc must die
 
   split_field("foo",":")                     # marc:must:die -> ['marc','must','die']
   join_field("foo",":")                      # ['marc','must','die'] -> marc:must:die
-  retain("id","id2","id3")                   # delete any field except 'id', 'id2', 'id3'
+
   replace_all("title","a","x")               # marc -> mxrc
 
   # Most functions can work also work on arrays. E.g.
@@ -69,28 +193,28 @@ parameters given.
 
   count("myarray")                           # count number of elements in an array or hash
   sum("numbers")                             # replace an array element with the sum of its values
+
   sort_field("tags")                         # sort the values of an array
   sort_field("tags", uniq:1)                 # sort the values plus keep unique values
   sort_field("tags", reverse:1)              # revese sort
   sort_field("tags", numeric:1)              # sort numerical values
+
   uniq(tags)                                 # strip duplicate values from an array
+
   filter("tags","[Cc]at")                    # filter array values tags = ["Cats","Dogs"] => ["Cats"]
+
   flatten(deep)                              # {deep => [1, [2, 3], 4, [5, [6, 7]]]} => {deep => [1, 2, 3, 4, 5, 6, 7]}
 
-  # {author => "tom jones"}  -> {author => "senoj mot"}
-  reverse(author)
-
-  # {numbers => [1,14,2]} -> {numbers => [2,14,1]}
-  reverse(numbers)
 
   # replace the value with a formatted (sprintf-like) version
   # e.g. numbers:
   #         - 41
   #         - 15
-  format(number,"%-10.10d %-5.5d") # numbers => "0000000041 00015"
+  format(number,"%-10.10d %-5.5d")           # numbers => "0000000041 00015"
+
   # e.g. hash:
   #        name: Albert
-  format(name,"%-10s: %s") # hash: "name      : Albert"
+  format(name,"%-10s: %s")                   # hash: "name      : Albert"
 
   parse_text(date, '(\d\d\d\d)-(\d\d)-(\d\d)')
   # date:
@@ -137,3 +261,197 @@ parameters given.
 
   # Add a new field 'foo' with a random value between 0 and 9
   random(foo, 10)
+
+  # Delete all empty fields from the record
+  vacuum()
+
+=head1 Convert from to JSON
+
+    # Convert my.field to a JSON string
+    to_json('my.field')
+
+    # Convert the JSON string into my.field into data
+    from_json('my.field')
+
+=head1 Lookup values in a file or database
+
+  # Lookup the value in 'title' in dict.csv and replace it with the value found
+  lookup("title","dict.csv", sep_char:'|')
+
+  # Lookup the value in 'title' in dict.csv and replace it with the value found
+  # Use 'test' as the default value
+  lookup("title","dict.csv", default:test)
+
+  # Lookup the value in 'title' in dict.csv and replace it with the value found
+  # Delete 'title' when no value has been found
+  lookup("title","dict.csv", delete:1)
+
+  # Lookup the value in 'title' a database and replace it with the value found
+  lookup_in_store('title', 'MongoDB', database_name:lookups)
+  lookup_in_store('title', 'MongoDB', default:'default value' , delete:1)
+
+=head1 Import data from a file or a database
+
+  # Replace the data in foo.bar with an external file or url
+  import(foo.bar, JSON, file: "http://foo.com/bar.json", data_path: data.*)
+
+=head1 Store data into a file or a database
+
+  add_to_store('authors.*', 'MongoDB', bag:authors, database_name:catalog)
+
+  # Store the 'data' field in a CSV file
+  add_to_exporter(data,CSV,header:1,file:/tmp/data.csv)
+
+  # Store the complete record into a CSV file
+  add_to_exporter(.,CSV,header:1,file:/tmp/data.csv)
+
+=head1 Execute all fixes from an external file
+
+  include('/path/to/myfixes.txt')
+
+=head1 Execute external commands
+
+  # Run every record through an external program and collect the results
+  # In the example below the Java program MyClass reads JSON records
+  # from the STDIN and writes it to the STDOUT
+  cmd("java MyClass")
+
+  # Run a Perl script as external fix program. The Perl script must
+  # contain an anonymous subroutine which manipulates the record given
+  perlcode("myscript.pl")
+
+  # Sleep for one second
+  sleep(1,SECOND)
+
+=head1 Write log messages to a Log4perl debugger
+
+  # Send debug messages to a logger
+  log('test123')
+  log('hello world' , level => 'DEBUG')
+
+=head1 Binds execute complex fixes (loops, error checks, ...)
+
+  # The identity binder doesn't embody any computational strategy. It simply
+  # applies the bound fix functions sequentially to its input without any
+  # modification.
+  do identity()
+    add_field(foo,bar)
+    add_field(foo2,bar2)
+  end
+
+  # Maybe, computes all the fix functions and ignores fixes once they throw errors
+  # or return undef.
+  do maybe()
+    foo()
+    return_undef() # rest will be ignored
+    bar()
+  end
+
+  # List over all items in demo and add a foo => bar field
+  # { demo => [{},{},{}] } => { demo => [{foo=>bar},{foo=>bar},{foo=>bar}]}
+  do list(path: demo)
+    add_field(foo,bar)
+  end
+
+  # Print statistical information on the processing speed of fixes to the standaard error.
+  do benchmark(output:/dev/stderr)
+    foo()
+  end
+
+  # Find all ISBN in a stream
+  do hashmap(exporter: JSON, join:',')
+    # Need an identity binder to group all operations that calculate key_value pairs
+    do identity()
+     copy_field(isbn,key)
+     copy_field(_id,value)
+    end
+  end
+
+  # Count the number of ISBN occurrences in a stream
+  do hashmap(count: 1)
+    copy_field(isbn,key)
+  end
+
+  # Filter out an array (needs Catmandu 0.9302 or better)
+  #    data:
+  #       - name: patrick
+  #       - name: nicolas
+  # to:
+  #    data:
+  #       - name: patrick
+  do with(path:data)
+    reject all_match(name,nicolas)
+    # Or:
+    # if all_match(name,nicolas)
+    #  reject()
+    # end
+  end
+
+  #  run fixes that should run within a time limit
+  do timeout(time => 5, units => seconds)
+    ...
+  end
+
+  # a binder that computes Fix-es for every element in record
+  do visitor()
+     # upcase all the 'name' fields in the record
+     if all_match(key,name)
+       upcase(scalar)
+     end
+  end
+
+  # a binder runs fixes on records from an importer
+  do importer(OAI,url: "http://lib.ugent.be/oai")
+    retain(_id)
+    add_to_exporter(.,YAML)
+  end
+
+=head1 MARC manipulation
+
+  # Copy all 245 subfields into the my.title hash
+  marc_map('245','my.title')
+
+  # Copy the 245-$a$b$c subfields into the my.title hash in the order of the record
+  marc_map('245abc','my.title')
+
+  # Copy the 245-$c$b$a subfields into the my.title hash in the order of the mapping
+  marc_map('245cba','my.title' , pluck:1)
+
+  # Copy the 100 subfields into the my.authors array
+  marc_map('100','my.authors.$append')
+
+  # Add the 710 subfields into the my.authors array
+  marc_map('710','my.authors.$append')
+
+  # Copy the 600-$x subfields into the my.subjects array while packing each into a genre.text hash
+  marc_map('600x','my.subjects.$append.genre.text')
+
+  # Copy the 008 characters 35-35 into the my.language hash
+  marc_map('008_/35-35','my.language')
+
+  # Copy all the 600 fields into a my.stringy hash joining them by '; '
+  marc_map('600','my.stringy', join:'; ')
+
+  # When 024 field exists create the my.has024 hash with value 'found'
+  marc_map('024','my.has024', value:found)
+
+  # Do the same examples now with the marc fields in 'record2'
+  marc_map('245','my.title', record:record2)
+
+  # Remove the 900 fields
+  marc_remove('900')
+
+  # Add a marc field (in Catmandu::MARC 0.110)
+  marc_add('999', ind1, ' ' , ind2, '1' , a, 'test123')
+
+  # Add a marc field populated with data from your record
+  marc_add('245', a , $.my.title.field, c , $.my.author.field)
+  
+  # Set a marc value of one (sub)field to a new value
+  marc_set('LDR/6','p')
+  marc_set('650p','test')
+  marc_set('100[3]a','Farquhar family.')
+
+  # Map all 650 subjects into an array
+  marc_map('650','subject', join:'###')
+  split_field('subject','###')

--- a/lib/Catmandu/Help/CommandLineClient.pm
+++ b/lib/Catmandu/Help/CommandLineClient.pm
@@ -1,0 +1,151 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Command Line Client
+
+Most of the Catmandu processing doesn't require you to write any code. With our
+command line tools you can store data files into databases, index your data,
+export data in various formats and provide basic data cleanup operations.
+
+=head2 convert
+
+The L<Catmandu::Cmd::convert> command is used to transfrom one format to another,
+or to download data from the Internet. For example, to extract all titles from a
+MARC record one can write:
+
+    $ catmandu convert MARC to CSV --fix 'marc_map(245a,title); retain(title)' < data.mrc
+
+In the example above, we import MARC and export it again as CSV while extracting
+the 245a field from a record and deleting all the rest. With the convert command
+one can transform data from one format to another.
+
+Transform JSON to YAML:
+
+    $ catmandu convert JSON to YAML < data.json
+
+Transform YAML to JSON:
+
+    $ catmandu convert YAML to JSON < data.json
+
+Convert Excel to CSV:
+
+    $ catmandu convert XLS to CSV < data.xls
+
+The L<Fix|Catmandu::Help::FixLanguage> language can be used to extract the fields
+from a input you are interested in.
+Convert Excel to CSV and only keep the titles, authors, and year columns:
+
+    $ catmandu convert XLS to CSV --fix 'retain(titles,authors,year)' < data.xls
+
+In formats such as JSON or YAML the data can be deeply nested. All these fields
+can be accessed and converted.
+
+    $ catmandu convert JSON --fix 'upcase(my.nested.field.1)' < data.xls
+
+In the example above a JSON input is converted by upcasing the field my that
+contains a field nested that contains a field field that contains a list for
+which the second item (indicated by 1) should be upcased.
+
+The convert command can also be used to extract data from a database. For example
+to download the Dublin Core data from the UGent institutional repository type:
+
+    $ catmandu convert OAI --url http://biblio.ugent.be/oai
+
+To get a CSV export of all identifiers in this OAI-PMH service type:
+
+    $ catmandu convert OAI --url http://biblio.ugent.be/oai to CSV --fix 'retain(_id)'
+
+Or a YAML file with all titles:
+
+    $ catmandu convert OAI --url http://biblio.ugent.be/oai --set public to YAML --fix 'retain(title)'
+
+=head2 import
+
+The import command is used to import data into a database. Catmandu provides support
+for NOSQL databases such as MongoDB, Elasticsearch and CouchDB which require
+no preconfiguration before they can be used. There is also support for relational
+databases such as Oracle, MySQL and Postgres via DBI or search engines like Solr
+but they need to be configured first (databases, tables, schemas need to be created first).
+
+Importing a JSON document into MongoDB database can be as simple as:
+
+    $ catmandu import JSON  to MongoDB --database_name bibliography < books.json
+
+Importing into a database can be done for every format that is supported by Catmandu.
+For instance, MARC can be imported with this command:
+
+    $ catmandu import MARC to MongoDB --database_name marc_data < data.mrc
+
+Or, XLS:
+
+    $ catmandu import XLS to MongoDB --database_name my_xls_data < data.xls
+
+Even a download from a website can be directly stored into a database.
+
+    $ catmandu import -v OAI --url http://biblio.ugent.be/oai to MongoDB --database_name oai_data
+
+In the example above a copy of the institutional repository of Ghent University
+was loaded into a MongoDB database. Use the option -v to see a progress report.
+
+Before the data is imported a Fix can be applied to extract fields or transform
+fields before they are stored into the database. For instance, we can extract
+the publication year from a MARC import and store this as a separate year field:
+
+    $ catmandu import MARC to MongoDB --database_name marc_data --fix 'marc_map("008/7-10",year)' < data.mrc
+export
+
+The export command is used to retreive data from a database. See the import command
+above for a list of databases that are supported.
+
+For instance we can export all the MARC records we have imported with this command:
+
+    $ catmandu export MongoDB --database_name marc_data
+
+In case we only need the title field from the marc records and want the results
+in a CSV format we can add some fixes:
+
+    $ catmandu export MongoDB --database_name marc_data to CSV --fix 'marc_map(245a,title); retain(title)'
+
+Some database support a query syntax to query for records to be exported. For
+instance, in the example above we extracted the year field form the MARC import.
+This can be used to only export the records of a particular year:
+
+    $ catmandu export MongoDB --database_name marc_data --query '{"year": "1971"}'
+
+=head2 configuration
+
+It is often handy to store the configuration options of importers, exporter and
+stores into a file. This allows you to create shorter easier commands. To do this
+a file C<catmandu.yml> needs to be created in your working directory with content like:
+
+    ---
+    importer:
+      ghent:
+         package: OAI
+         options:
+            url: http://biblio.ugent.be
+            set: public
+            handler: marcxml
+            metadataPrefix: marc21
+    store:
+      ghentdb:
+         package: MongoDB
+         options:
+            database_name: oai_data
+            default_bag: data
+
+When this file is available, an OAI-PMH harvest could be done with the shortened command:
+
+    $ catmandu convert ghent
+
+To store the ghent OAI-PMH import into the MongoDB database, one could write:
+
+    $ catmandu import ghent to ghentdb
+
+To extract the data from the database, one can write:
+
+    $ catmandu export ghentdb
+    

--- a/lib/Catmandu/Help/Comments.pm
+++ b/lib/Catmandu/Help/Comments.pm
@@ -1,0 +1,15 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Comments
+
+C<Comments> can be added to the Fix scripts to enhance the readability of your transformations.
+All lines that start with a hash sign (#) are ignored by Catmandu:
+
+    # This is a comment
+      # This is also a comment
+    add_field(foo,bar)  #This is a comment at the and of a line, add_field will be executed
+    # remove_field(foo) this line is a comment, remove_field(foo) will not be executed by the script

--- a/lib/Catmandu/Help/Concepts.pm
+++ b/lib/Catmandu/Help/Concepts.pm
@@ -1,0 +1,27 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Concepts
+
+To better make use of Catmandu is helps to first understand its B<core concepts>:
+
+L<Items|Catmandu::Help::Items> are the basic unit of data processing in Catmandu.
+Items can be read, stored, and accessed in many formats. An item can be a MARC
+record or a RDF triple or one row in an Excel file.
+
+L<Importers|Catmandu::Help::Importers>  are used to read items. There are importers
+for MARC, JSON, YAML, CSV, Excel, and many other input formats. One can also
+import from remote sources such as SPARQL, Atom and OAI-PMH endpoints.
+
+L<Exporters|Catmandu::Help::Exporters>  are used to transform items back into JSON,
+YAML, CSV, Excel or any format you like.
+
+L<Stores|Catmandu::Help::Stores>  are database to store your data. With database
+such MongoDB and ElasticSearch it becomes really, really easy to store quite
+complicated, deeply nested, items.
+
+L<Fixes|Catmandu::Help::Fixes> transforms items, transform the data into any
+format you like. See Fix language and Fix packages for details.

--- a/lib/Catmandu/Help/Conditionals.pm
+++ b/lib/Catmandu/Help/Conditionals.pm
@@ -1,0 +1,142 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Conditionals
+
+A B<Conditional> is executed depending on a boolean condition that can be
+true or false. For instance, to skip a Catmandu item when the field C<error> exists
+one would use the conditional C<exists>:
+
+    if exists(error)
+      reject()
+    end
+
+A condition contains an C<if> or C<unless> statement a B<Conditional> (Fix functions
+which can be true or false), a C<body> of zero or more Fix functions and an
+optional C<elsif> or C<else> clause:
+
+    if exists(error)
+       # Write here all the Fix functions when the field 'error' exists
+    end
+
+    unless exists(error)
+      # Write here all the Fix functions when the field 'error' doesn't exist
+    end
+
+    if exists(error)
+       # If error exists then do this
+    elsif exists(warning)
+       # If warning exists then do this
+    else
+       # otherwise do this
+    end
+
+Catmandu also supports a limited number of boolean operators:
+
+    exist(foo)  and add_field(ok,1)     # only execute add_field() when 'foo' exists
+    exists(foo) or  add_field(error,1)  # only execute add_field() when 'foo' doesn't exist
+
+Below follows some basic fix functions that are implemented in Catmandu. Check
+the manual pages of the individual Catmandu extensions for more elaborate Conditionals.
+
+=head2 all_equal(path,value)
+
+True, when the path exists and is exactly equal to a value. When the path points to a
+list, then all the list members need to be equal to the value. False otherwise.
+
+    if all_equal(year,"2018")
+      set_field(published,"future")
+    end
+
+    if all_equal(animals.*,"cat")
+      set_field(animal_types,"feline")
+    end
+
+=head2 any_equal(path,value)
+
+True, when the path exists and is exactly equal to a value. When the path points to a list,
+then at least one of the list members need to be equal to the value. False otherwise.
+
+    if any_equal(year,"2018")
+      set_field(published,"future")
+    end
+
+    if any_equal(animals.*,"cat")
+      set_field(animal_types,"some feline")
+    end
+
+=head2 all_match(path,regex)
+
+True, when the path exists and the value matched the regex regular expression. When
+the path points to a list, then all the values have to match the regular expression.
+False otherwise.
+
+    if all_match(year,"^19.*$")
+      set_field(period,"20th century")
+    end
+
+    if all_match(publishers.*,"Elsevier.*")
+      set_field(is_elsevier,1)
+    end
+
+=head2 any_match(path,regex)
+
+True, when the path exists and the value matched the regex regular expression. When
+the path points to a list, then at least one of the values has to match the regular
+expression. False otherwise.
+
+    if any_match(year,"^19.*$")
+      set_field(period,"20th century")
+    end
+
+    if any_match(publishers.*,"Elsevier.*")
+      set_field(some_elsevier,1)
+    end
+
+=head2 exists(path)
+
+True, when the path exists in the Catmandu item. False otherwise.
+
+    if exists(my.deep.field)
+    end
+
+    if exists(my.list.0)
+    end
+
+=head2 greater_than(path,number)
+
+True, when the path exists and the value is greater than a number. When the path points
+to a list, then all the members need to be greater than the number. False otherwise.
+
+=head2 less_than(path,number)
+
+True, when the path exists and the value is less than a number. When the path points
+to a list, then all the members need to be less than the number. False otherwise.
+
+=head2 in(path1,path2)
+
+True, when the values of the first path1 are contained in the values at the second path2.
+False otherwise.
+
+For instance to check if two paths contain the same values type:
+
+    if in(my.title,your.title)
+      set_field(same,1)
+    end
+
+To check if a value in one path is contained in a list of an other path type:
+
+    if in(my.author,your.authors.*)
+       set_field(known_author,1)
+    end
+
+=head2 is_true(path)
+
+True, if the value at path can be evaluated to a boolean true. False otherwise
+
+=head2 is_false(path)
+
+True, if the value at path can be evaluated to a boolean false. False otherwise

--- a/lib/Catmandu/Help/Exporters.pm
+++ b/lib/Catmandu/Help/Exporters.pm
@@ -1,0 +1,79 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Exporters
+
+Exporters are Catmandu packages to export data in specific format. See
+L<Importers|Catmandu::Help::Importers> for the opposite action.
+
+Some exporter such as JSON and YAML can handle any type of input. It doesn't matter
+how the input is structured, it is always possible to create a JSON or YAML file.
+
+Exporter are given after the to argument to the convert command
+
+    $ catmandu convert OAI --url http://biblio.ugent.be/oai to JSON
+    $ catmandu convert MARC to JSON
+    $ catmandu convert XLS to JSON
+
+For most exporters however, the input data needs to be structured in a specific
+format. For instance, tabular formats such as Excel, CSV and TSV don't allow for
+nested fields. In the example below, catmandu tried to convert a list into a
+simple value which will fail:
+
+    $ echo '{"colors":["red","green","blue"]}' | catmandu convert JSON to CSV
+    colors
+    ARRAY(0x7f8885a16a50)
+
+The is an ARRAY output, indicating that the colors field is nested. To fix this,
+a transformation needs to be provided:
+
+    $ echo '{"colors":["red","green","blue"]}' | catmandu convert JSON to CSV --fix 'join_field(colors,",")'
+    colors
+    "red,green,blue"
+
+MARC output should have an input in the Catmandu MARC format, RDF exports need
+the aREF format, etc etc.
+
+Exporter also accept options to configure the various kinds of exports. For instance, J
+SON can be exporter in a array or line by line format
+
+    $ catmandu convert MARC to JSON --array 1 < data.mrc
+    $ catmandu convert MARC to JSON --line_delimited 1 < data.mrc
+    $ catmandu convert MARC to JSON --pretty 1 < data.mrc
+
+The L<Catmandu::Template> package can be used to generate any type of structured output
+given an input using the L<Template> Toolkit language.
+
+For instance, to create a JSON array of colors an echo command can used on Linux:
+
+    $ echo '{"colors":["red","green","blue"]}'
+
+To transform this JSON into XML, the Template exporter can be used with a template file
+as a command line argument:
+
+    $ echo '{"colors":["red","green","blue"]}' | catmandu convert JSON to Template --template `pwd`/xml.tt
+
+and xml.tt like:
+
+    <colors>
+    [% FOREACH c IN colors %]
+      <color>[% c %]</color>
+    [% END %]
+    </colors>
+
+will produce:
+
+    <colors>
+      <color>red</color>
+      <color>green</color>
+      <color>blue</color>
+    </colors>
+
+Consult the manual pages of catmandu to see the output options of the different Exporters:
+
+    $ catmandu help export JSON
+    $ catmandu help export YAML
+    $ catmandu help export CSV

--- a/lib/Catmandu/Help/FixLanguage.pm
+++ b/lib/Catmandu/Help/FixLanguage.pm
@@ -1,0 +1,17 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Fix language
+
+Catmandu comes with a small domain specific language for manipulation of data
+L<Items|Catmandu::Help::Items> called Fix. The Fix consists of
+
+  * L<Paths|Catmandu::Help::Paths> to refer to particular parts of an item
+  * L<Functions|Catmandu::Help::Functions> to manipulate (parts of) an item
+  * L<Selectors|Catmandu::Help::Selectors> to manipulate which items end up in the end result
+  * L<Conditionals|Catmandu::Help::Conditionals> to control when to apply which Fix functions
+  * L<Binds|Catmandu::Help::Binds> to manipulate the execution of Fix functions
+  * L<Comments|Catmandu::Help::Comments> to provide documentation in the Fix script

--- a/lib/Catmandu/Help/Fixes.pm
+++ b/lib/Catmandu/Help/Fixes.pm
@@ -1,0 +1,104 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Fixes
+
+Fixes are used for easy data transformations by non programmers. Using a small
+L<Fix language|Catmandu::Help::FixLanguage> non-programmers can manipulate
+Catmandu L<Items|Catmandu::Help::Items>.
+
+To introduce the capabilities of Fix, an example will be provided below to extract
+data from a MARC input.
+
+First, make sure that Catmandu::MARC is installed on your system.
+
+ $ sudo cpanm Catmandu::MARC
+
+We will use the Catmandu command line client to extract data from an example USMARC
+file that can be downloaded via this link: L<https://github.com/LibreCat/Catmandu/wiki/files/camel.usmarc>.
+
+With the convert command one can read items from a MARC Importer and convert it into a
+new format. By default, convert will output JSON:
+
+    $ catmandu convert MARC < camel.usmarc
+    {"record":[["LDR",null,null,"_","00755cam  22002414a 4500"],["001",null,null...
+    ...
+    ["650"," ","0","a","Cross-platform software development."]],"_id":"fol05882032 "}
+
+You can make this conversion explicit:
+
+    $ catmandu convert MARC to JSON < camel.usmarc
+
+To transform this MARC data we first will create a Fix file which contains all the Fix
+commands we will use. Create a text file 'fixes.txt' on your system with this input:
+
+    remove_field('record');
+
+and execute the following command:
+
+    $ catmandu convert MARC --fix fixes.txt < camel.usmarc
+    {"_id":"fol05731351 "}
+    {"_id":"fol05754809 "}
+    {"_id":"fol05843555 "}
+    {"_id":"fol05843579 "}
+
+We have removed the field 'record' (containing the MARC data) from the JSON record.
+This is what the 'remove_field' Fix does: remove one field in a JSON record. We will use
+this remove_field('record') to make our output a bit more terse and easier readable.
+
+With the 'marc_map' Fix from the Catmandu::MARC package we can extract MARC (sub)fields
+from the record. Add these to the fixes.txt file:
+
+    marc_map('245','title');
+    remove_field('record');
+
+When we run our previous catmandu command we get the following output:
+
+    $ catmandu convert MARC --fix fixes.txt to JSON --line_delimited 1 < camel.usmarc
+    {"_id":"fol05731351 ","title":"ActivePerl with ASP and ADO /Tobias Martinsson."}
+    {"_id":"fol05754809 ","title":"Programming the Perl DBI /Alligator Descartes and Tim Bunce."}
+    {"_id":"fol05843555 ","title":"Perl :programmer's reference /Martin C. Brown."}
+
+We know that in the 650-a field of MARC we can find subjects. Lets add them to the fixes.txt:
+
+    marc_map('245','title');
+    marc_map('650a','subject');
+    remove_field('record');
+
+and run the command again:
+
+    $ catmandu convert MARC --fix fixes.txt to JSON --line_delimited 1 < camel.usmarc
+    {"subject":"Perl (Computer program language)","_id":"fol05731351 ","title":"ActivePerl with ASP and ADO /Tobias Martinsson."}
+    {"subject":"Perl (Computer program language)Database management.","_id":"fol05754809 ","title":"Programming the Perl DBI /Alligator Descartes and Tim Bunce."}
+    {"subject":"Perl (Computer program language)","_id":"fol05843555 ","title":"Perl :programmer's reference /Martin C. Brown."}
+
+The MARC 008 field from position 7 to 10 contains publication years. We can also add these to the 'fixes.txt' file:
+
+    marc_map('245','title');
+    marc_map('650a','subject');
+    marc_map('008/7-10,'year');
+    remove_field('record');
+
+and run the command:
+
+    $ catmandu convert MARC --fix fixes.txt to JSON --line_delimited 1 < camel.usmarc
+    {"subject":"Perl (Computer program language)","_id":"fol05731351 ","title":"ActivePerl with ASP and ADO /Tobias Martinsson.","year":"2000"}
+    {"subject":"Perl (Computer program language)Database management.","_id":"fol05754809 ","title":"Programming the Perl DBI /Alligator Descartes and Tim Bunce.","year":"2000"}
+    {"subject":"Perl (Computer program language)","_id":"fol05843555 ","title":"Perl :programmer's reference /Martin C. Brown.","year":"1999"}
+
+You don't need to write fixes into a file to use them. E.g. if we want to have some statistic on the publication year in the camel.usmarc file we can do something like:
+
+    $ catmandu convert MARC --fix "marc_map('008/7-10','year'); retain_field('year')" to CSV < camel.usmarc
+    year
+    2000
+    2000
+    1999
+    .
+    .
+
+With marc_map we extracted the year form the 008 field. With retain_field we deleted everything
+in the output except for the field 'year'. We used the CSV Exporter to present the results in an
+easy format.

--- a/lib/Catmandu/Help/Functions.pm
+++ b/lib/Catmandu/Help/Functions.pm
@@ -1,0 +1,85 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Functions
+
+Fix functions manipulate fields in every item of a Catmandu L<Importer|Catmandu::Help::Importers>.
+For instance, using the command below the title field will be upcased for every
+item in the input list of JSON items.
+
+    $ catmandu convert JSON --fix 'upcase(title)' < data.json
+
+Fix functions can have zero or more B<arguments> separated by commas:
+
+    vacuum()              # Clean all empty fields in a record
+    upcase(title)         # Upcase the title value
+    append(title,"-123")  # Add -123 at the end of the title value
+
+The arguments to a Fix function can be a B<Fix path> or a B<string literal>.
+String literals can be quoted with double or single quotes.
+
+    append(title,"-123")
+    append(title,'foo bar')
+
+In case of single quotes all the characters between quotes will be interpreted verbatim.
+When using double quotes, the values in quotes can be interpreted by some Fix functions.
+
+    replace_all(title,"My (.*) Pony","Our $1 Fish")   # Replace 'My Little Pony' by 'Our Little Fish'
+
+Some Fix functions accept zero or more B<options> which need to be specified as
+a C<name> C<:> C<value> pair:
+
+    sort_field(tags, reverse:1)               # Sort the tags field in reverse order
+    lookup("title","dict.csv", sep_char:'|',default:'NONE')  # Lookup a title in a CSV file
+
+Unless specified otherwise (such as in L<Binds|Catmandu::Help::Binds>), Fix function
+ are executed in the order given by the Fix script:
+
+    upcase(authors.*)
+    append(authors.*,"abc")
+    replace_all(authors.*,"a","AB")
+
+In the example above all transformations on the field C<authors> will be executed in
+the order given. For example when the field authors contains this list:
+
+    ---
+    authors:
+      - John
+      - Mary
+      - Dave
+
+The first fix will transform this list into:
+
+    ---
+    authors:
+      - JOHN
+      - MARY
+      - DAVE
+
+The second fix will append "abc" to all authors
+
+    ---
+    authors:
+      - JOHNabc
+      - MARYabc
+      - DAVEabc
+
+The third fix will replace all "a"-s by "AB"s
+
+    ---
+    authors:
+      - JOHNABbc
+      - MARYABbc
+      - DAVEABbc
+
+In some cases the ordering of transformations of items in a list matters.
+For instance, you want to first do a sequence of transformation on all first
+items in a list, then a sequence of transformations on all second items in a
+list, etc. To change this ordering of Fix functions L<Binds|Catmandu::Help::Binds>
+need to be used.
+
+For a nearly complete list of functions currently available in Catmandu, take a
+look at the L<Fixes Cheat Sheet|Catmandu::Help::CheatSheet>.

--- a/lib/Catmandu/Help/Glossary.pm
+++ b/lib/Catmandu/Help/Glossary.pm
@@ -1,0 +1,65 @@
+1;
+=head1 NAME
+
+Catmandu::Help::Glossary - A glossary of Catmandu basic concepts
+
+=head1 GLOSSARY
+
+=head2 bind
+
+Part of the L</fix language>.
+
+=head2 catmandu
+
+Name of the data processing framework L<Catmandu> (uppercase) and its command
+line client L<catmandu> (lowercase).
+
+=head2 conditional statement
+
+Part of the L</fix language> to control execution of fix functions depending
+on whether an item mets some given condition or not. The syntax of conditional
+statements is "C<if ... end>", "C<if ... else ... end>", or "C<unless ... end>".
+
+=head2 exporter
+
+Can transform L<item|/items> back into a format such as JSON, YAML, CSV, Excel,
+XML ...
+
+=head2 fix
+
+A script written in the L</fix language> or another program that modifies items.
+
+=head2 fix function
+
+A statement of the L<fix language> to modify an item or perform some check on
+it.  A L</path language> is used to refer to selected parts of an item.
+
+=head2 fix language
+
+A domain-specific language for manipulation of items. It consists of 
+L<fix functions|/fix function>, L<conditional statements/conditional statements>,
+and L<binds|/bind>.
+
+=head2 importer
+
+Can transform data from a format such as JSON, YAML, CSV, Excel, XML etc. into an
+L</item> for further processing.
+
+=head2 item 
+
+A single data record as processed in Catmandu. Items are data structures build
+of key-value pairs ("objects"), lists ("arrays"), strings, numbers, and the
+special null-value. All items can be expressed in L<JSON|http://json.org> and
+YAML, among other formats.
+
+=head2 iterator
+
+A sequence of L<items|/item>, for instance the list of rows from a CSV file or
+the result list or a query.
+
+=head2 validator
+
+A L</fix function> that checks whether an L</item> (or a part of it) conforms
+to some given schema or another kind of test.
+
+=cut

--- a/lib/Catmandu/Help/Importers.pm
+++ b/lib/Catmandu/Help/Importers.pm
@@ -1,0 +1,52 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Importers
+
+Importers are Catmandu packages to read a specific data format. Catmandu provides
+importers for MARC, JSON, YAML, CSV, Excel, and many other input formats. One
+can also import from remote sources for instance via protocols such as SPARQL
+and OAI-PMH.
+
+The name of a Catmandu importer should be provided as first argument to the
+convert command.
+
+Read JSON input:
+
+    $ catmandu convert JSON
+
+Read YAML input
+
+    $ catmandu convert YAML
+
+Read MARC input
+
+    $ catmandu convert MARC
+
+The Importer accepts configurable options. The following arguments to the MARC
+importer are currently supported:
+
+  * USMARC (use ISO as an alias)
+  * MicroLIF
+  * MARCMaker
+  * MiJ (for MARC-in-JSON)
+  * XML (for MARCXML)
+  * RAW
+  * Lint
+  * ALEPHSEQ(for Aleph Sequential)
+
+Read MARC-XML input
+
+    $ catmandu convert MARC --type XML < marc.xml
+
+Read Aleph sequential input
+
+    $ catmandu convert MARC --type ALEPHSEQ < marc.txt
+
+Read more about the configuration options of importers by reading their manual pages:
+
+    $ catmandu help import JSON
+    $ catmandu help import YAML

--- a/lib/Catmandu/Help/Introduction.pm
+++ b/lib/Catmandu/Help/Introduction.pm
@@ -1,0 +1,27 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Introduction
+
+Catmandu is a command line tool to access and convert data from your digital library,
+research services or any other open data sets. The toolkit was originally developed
+as part of the L<LibreCat|https://github.com/LibreCat/Catmandu/wiki/LibreCat> project
+and attracts now an international development team with many participating institutions.
+
+Catmandu has the following features, one can:
+
+  * download data via protocols such as OAI-PMH, SRU, SPARQL and Linked Data Fragments.
+  * convert formats library format such as MARC, MODS, Dublin Core and but also others like JSON, YAML, XML, Excel and many more.
+  * generate RDF and speak the Semantic Web.
+  * index data into databases such as Solr, Elasticsearch and MongoDB.
+  * use a simple L<Catmandu::Help::Fix> language to convert metadata into any format you like.
+
+Catmandu is used in the LibreCat project to build institutional repositories and
+search engines. Catmandu is used on the command line for quick and dirty reports
+but also as part of larger programming projects processing millions of records per
+day. For a short overview of use-cases, see our L<Homepage|http://librecat.org/use-cases.html>.
+
+There are than 60 Catmandu projects available at L<GitHub|https://github.com/organizations/LibreCat>.

--- a/lib/Catmandu/Help/Items.pm
+++ b/lib/Catmandu/Help/Items.pm
@@ -1,0 +1,49 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Items
+
+An B<item> is the basic unit of data processing in Catmandu. Items are data
+structures build of key-value-pairs (aka objects), lists (aka arrays), strings,
+numbers, and null-values. All items can be expressed in JSON and YAML, among
+other formats.
+
+Internally all data processing by Catmandu is using a generic data format not
+unlike JSON. If one imports MARC, XML, Excel, OAI-PMH, SPARQL, data from a
+database or any other format, everything can be expressed as JSON.
+
+For example:
+
+  * JSON/YAML - when importing a large JSON/YAML collections as an array, every item is a Catmandu item.
+  * Text - for text import every line of text is one Catmandu item.
+  * MARC - when importing MARC data, every record in a MARC file is one Catmandu item.
+  * XLS,CSV - for tabular formats such as Excel, CSV and TSV, each row in a table is one Catmandu item
+  * RDF - for linked data formats such as RDF/XML, RDF/nTriples, RDF/Turtle each triple is one Catmandu item
+  * SPARQL - for a result set of a SPARQL or LDF query, every result (with the variable bindings) is one Catmandu item
+  * MongoDB,ElasticSearch,Solr,DBI - for databases every record in the database is one Catmandu item
+
+To transform items with the L<Fix Language|Catmandu::Help::FixLanguage> one points to the
+fields in items with a JSONPath expression (Catmandu uses an extension of JSONPath actually).
+The fixes provided to a catmandu command operate on all individual items.
+
+For instance, the command below will upcase the publisher field for every item (row)
+in the data.xls file:
+
+    $ catmandu convert XLS --fix 'upcase(publisher)' < data.xls
+
+This command will select only the JSON items that contain 'Tsjechov' in a nested authors field:
+
+    $ catmandu convert XLS --fix 'select any_match(authors.*,"Tsjechov.*")' < data.json
+
+This command will delete all the uppercase A characters from a Text file:
+
+    $ catmandu convert Text to Text --fix 'replace_all(A,"")' < data.txt
+
+To see the internal representation of a MARC file in Catmandu, transform it for instance to YAML
+
+    $ catmandu convert MARC to YAML < data.mrc
+
+One will see that a MARC record is treated as an array of arrays for each item.

--- a/lib/Catmandu/Help/Paths.pm
+++ b/lib/Catmandu/Help/Paths.pm
@@ -1,0 +1,133 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Paths
+
+=head2 Paths
+
+Almost any transformation on a Catmandu item contains a path to the part of the
+item that needs to be changed. To upcase the C<title> field in an item the Fix
+C<upcase> needs to be used:
+
+    upcase(title)
+
+A field can be nested in B<key-value-pairs> (objects). To access the field deep
+in a key-value-pair, the B<dot-notation> should be used:
+
+    upcase(my.deep.nested.title)
+
+If a part of an item contains a B<list> of fields than the B<index-notation> should
+be used. Use index 0 to point to the first item in a list, index 1 to point to
+the second item in a list, index 3 to the third, etc, etc.
+
+    upcase(my.data.2.title)  # upcase the title of the 3rd item in the my.data list
+
+For example, given this YAML input:
+
+    ___
+    title: My Little Pony
+    my:
+     colors:
+       - red
+       - green
+       - blue
+     nested:
+         a:
+          b:
+           c: Hoi!
+
+The value 'My Little Pony' can be accessed using the path:
+
+    title
+
+The value 'green' can be accessed using the path:
+
+    my.colors.1
+
+The value 'Hoi!' can be accessed using the path:
+
+    my.nested.a.b.c
+
+=head2 Wildcards
+
+Wildcards are used to point to relative positions or many positions in a list.
+
+To point to the B<first item> in a list (e.g. the value 'red' in the example above)
+the wildcard C<$first> can be used:
+
+    my.colors.$first
+
+To point to the B<last item> in a list (e.g. the value 'blue' in the example above)
+the wildcard C<$last> can be used:
+
+    my.colors.$last
+
+In some cases, one needs to point to a position before the first item in a list.
+For instance, add a new field before the color 'red' in our example above, the wildcard
+C<$prepend> should be used:
+
+    my.colors.$prepend
+
+This wildcard can be used in the functions like set_field:
+
+    set_field(my.colors.$prepend,'pink')
+
+To add a new field add the end of a list (after the color 'blue'), the wildcard
+C<$append> should be used:
+
+    my.colors.$append
+
+As in:
+
+    set_field(my.colors.$append,'yellow')
+
+The B<star notation> is used to point to all the items in a list:
+
+    my.colors.*
+
+To upcase all the colors use:
+
+    upcase(my.colors.*)
+
+When list are nested inside lists, then wildcards can also be nested:
+
+    my.*.colors.*
+
+The above trick can be used when the my field contains a list which contains a
+color field which contains again a list of data. E.g.
+
+    ---
+    my:
+     - colors:
+         - red
+         - blue
+     - colors:
+         - yellow
+         - green
+
+=head2 MARC, MAB, PICA paths
+
+For some data formats is can be quite difficult to extract data by the exact
+position of a field. In data formats such as MARC, one is unsually not interested
+in a field in the 17th position which contains a subfield in position 3. MARC
+contains tags and subfields, which can be at any position in the MARC record.
+
+Specialized Fix functions for MARC, MAB and PICA make it easier to access data
+by changing the Path syntax. For instance, to copy the 245a field in a MARC
+record to the title field one can write:
+
+    marc_map("245a",title)
+
+In the context of a marc_map Fix the "245a" Path is a B<MARC Path> that points to
+a part of the MARC record. These MARC Paths only work in MARC Fixes (
+C<marc_map>, C<marc_add>, C<marc_set>, C<marc_remove>). It is not possible to
+use these paths in other Catmandu fix functions:
+
+    marc_map("245a",title)            # This will work
+    copy_field("246a","other_title")  # This will NOT work
+
+Consult the documentation of the different specialised packages for the Path syntax
+that can be used.

--- a/lib/Catmandu/Help/Selectors.pm
+++ b/lib/Catmandu/Help/Selectors.pm
@@ -1,0 +1,45 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Selectors
+
+With B<Fix selectors> one can select which Catmandu items can end up in an output
+stream or not. Using a selector to throw away the records you are not interested
+in. For instance, to filter out all the records in a input use the B<reject()>
+selector:
+
+    $ catmandu MARC to YAML --fix "reject()" < data.mrc
+
+The command above will generate no output: every record is rejected. The opposite
+of reject() is the B<select()> selector which can be used to select all the Catmandu
+items you want to keep in an output:
+
+    $ catmandu MARC to YAML --fix "select()" < data.mrc
+
+The command above will return all the MARC items in the input file.
+
+Selectors are of little use when used in isolation. Most of the time they are combined
+with L<Conditionals|Catmandu::HelpConditionals>. To select only the MARC records
+that have "Tsjechov" in the 100a field one can write:
+
+    $ catmandu MARC to YAML --fix "select marc_match(100a,'.*Tsjechov.*') " < data.mrc
+
+There are two alternative ways to combine selector with a conditional.
+Using the C<guard> syntax, the conditional is written C<after> the selector:
+
+    reject exits(error.field)
+    reject all_match(publisher,'xyz')
+    select any_match(years,2005)
+
+Using the C<if>/C<then>/C<else> syntax the conditional is written explicitly:
+
+    if exists(error.field)
+       reject()
+    end
+
+    if all_match(publisher,'xyz')
+       reject()
+    end

--- a/lib/Catmandu/Help/Stores.pm
+++ b/lib/Catmandu/Help/Stores.pm
@@ -1,0 +1,62 @@
+1;
+
+=pod
+
+=encoding utf8
+
+=head1 Stores
+
+Store are Catmandu packages to store Catmandu L<Items|Catmandu::Help::Items> in a
+database. These databases need to be installed separately from Catmandu. Special
+database such as MongoDB, ElasticSearch and CouchDB can work out-of-the-box with
+hardly any configuration. For other databases such as Solr, MySQL, Postgres and
+Oracle extra configuration steps are needed to define the database schemas.
+
+Catmandu stores such as MongoDB, ElasticSearch and CouchDB can accept any type of
+input. They are perfect tools to store the output of data conversions.
+
+Without defining any database schema, JSON, YAML , MARC, Excel, CSV, OAI-PMH or
+any other Catmandu supported format can be stored.
+
+    $ catmandu import JSON to MongoDB --database_name test < data.json
+    $ catmandu import YAML to MongoDB --database_name test < data.yml
+    $ catmandu import MARC to MongoDB --database_name test < data.mrc
+    $ catmandu import XLS to MongoDB --database_name test  < data.xls
+
+Many Catmandu stores can be queried with their native query language:
+
+    $ catmandu export MongoDB --database_name test --query '{"my.deep.field":"abc"}'
+
+To delete data from a store the delete command can be used.
+
+    # Delete everything
+    $ catmandu delete MongoDB --database_name test
+    # Delete record with _id = 1234 and _id = 1235
+    $ catmandu delete MongoDB --database_name test --id 1234 --id 1235
+
+Use the count command to show the size of a database.
+
+    $ catmandu count MongoDB --database_name test
+
+One important use-case for Catmandu is indexation of data in search engines such
+as Solr. To do this, Solr needs to be configured for the fields you want to make
+searchable. Your data collection can be indexed in the Solr engine by mapping the
+fields in your data to the fields available in Solr.
+
+    $ catmandu import MARC to Solr --fix marc2solr.fix < data.mrc
+
+where marc2solr.fix is a Fix script containing all the fixes required to transform
+your input data in the Solr format:
+
+    # marc2solr.fix
+    marc_map('008_/7-10','year')
+    marc_map('020a','isbn.$append')
+    marc_map('022a','issn.$append')
+    marc_map('245a','title_short')
+    .
+    .
+    .
+
+In reality the Fix script will contain many mappings and data transformations to
+clean data. See L<Example Fix Script|Catmandu::Help::ExampleFixScript> for a long
+example of such a data cleaning in action.


### PR DESCRIPTION
The description of basic Catmandu concepts should be moved from the
Catmandu Wiki to a Perl module so it can be used both in the CLI help
and in the HTML documentation.

To create HTML view with Pandoc and Pandoc::Elements:

```
pod2pandoc lib/Catmandu/Help/Glossary.pm | \
    pandoc -f json -t markdown | pandoc -s
```
