### PR TITLE
fix docs referring to wrong logger class

### DIFF
--- a/lib/Catmandu.pm
+++ b/lib/Catmandu.pm
@@ -278,13 +278,13 @@ C<use> command, these configuration files will be loaded at the start of your sc
 
 =head2 log
 
-Return the current L<Log::Any::Adapter> logger.
+Return the current L<Log::Any> logger.
 
     use Catmandu;
     use Log::Any::Adapter;
     use Log::Log4perl;
 
-    Log::Any::Adapter->set('Log4perl');
+    Log::Any::Adapter->set('Log4perl'); # requires Log::Any::Adapter::Log4perl
     Log::Log4perl::init('./log4perl.conf');
 
     my $logger = Catmandu->log;


### PR DESCRIPTION
When using Log::Any, the logger object code uses to generate log messages is technically Log::Any::Proxy. The Log::Any::Adapter is what takes those generated logs and does something with them (like forwards them to Log::Log4perl). I also added a note about installing Log::Any::Adapter::Log4perl to get the example to work correctly.