### PR TITLE
Fix the shebang line

### DIFF
--- a/bin/catmandu
+++ b/bin/catmandu
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 use Catmandu;
 use Catmandu::CLI;


### PR DESCRIPTION
Using "#!perl" means that perl's build tools will replace this line with
the absolute path of the perl binary installed against.

Using /usr/bin/env breaks the command line tool for users who have
multiple versions of perl installed and want to use a version other than
the first one found in $PATH.