### PR TITLE
Pr/dotted paths

### DIFF
--- a/lib/Catmandu/Fix.pm
+++ b/lib/Catmandu/Fix.pm
@@ -700,11 +700,6 @@ sub emit_clone {
     "$var = clone($var);";
 }
 
-sub __split_path {
-    my ($self, $path) = @_;
-    return [split /[\/\.]/, trim($path)];
-}
-
 ##
 # This function will split a path on a '.' or a '/',
 # but not on '\.' or '\/'.

--- a/lib/Catmandu/Fix.pm
+++ b/lib/Catmandu/Fix.pm
@@ -700,9 +700,53 @@ sub emit_clone {
     "$var = clone($var);";
 }
 
-sub split_path {
+sub __split_path {
     my ($self, $path) = @_;
     return [split /[\/\.]/, trim($path)];
+}
+
+##
+# This function will split a path on a '.' or a '/',
+# but not on '\.' or '\/'.
+sub split_path {
+    my ($self, $path) = @_;
+    
+    my @splitted_path;
+    my @component;
+
+    my @chars = split(//, trim($path));
+
+    foreach my $char (@chars) {
+        if ($char eq '.' || $char eq '/') {
+            my $previous = pop(@component);
+
+            # If $previous equals \, do not split on $char and append
+            # $char to @component. It is a part of the path key, not the path.
+            # $previous is thrown away if it is \, as it is nowhere in the
+            # original path.
+            if (defined($previous)) {
+                if ($previous eq '\\') {
+                    push(@component, $char);
+                } else {
+                    # Perform the split action
+                    push(@component, $previous);
+                    push(@splitted_path, join('', @component));
+                    # Empty @component
+                    @component = ();
+                }
+            }
+        } else {
+            # It is not a split char, so add to @component
+            push(@component, $char);
+        }
+    }
+
+    # Add the last @component (between the last ./ and the end of the string)
+    if (scalar @component != 0) {
+        push(@splitted_path, join('', @component));
+    }
+
+    return \@splitted_path;
 }
 
 1;

--- a/t/Catmandu-Fix-dotted_path.t
+++ b/t/Catmandu-Fix-dotted_path.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+my $add;
+my $copy;
+
+BEGIN {
+    $add = 'Catmandu::Fix::add_field';
+    use_ok $add;
+    $copy = 'Catmandu::Fix::copy_field';
+    use_ok $copy;
+}
+
+is_deeply $add->new('with\.a\.dot', 'Train')->fix({}),
+    {'with.a.dot' => 'Train'}, "add field with.a.dot";
+
+is_deeply $copy->new('with\.a.dot', 'no.dot')->fix({'with.a' => {'dot' => 'Train'}}),
+    {'no' => {'dot' => 'Train'}, 'with.a' => {'dot' => 'Train'}}, "move field with a dot to one without";
+
+done_testing 4;


### PR DESCRIPTION
Updated the split_path function to support paths of which the keys have dots.

Previously, it was impossible to get or set a key in path which contained dots as part of the key. Added an escape character (`\`), so this is now possible.

### Example
```
<foo>
    <my.first.name>Pieter</my.first.name>
</foo>
```

This can now be addressed in the fix language as: `foo.my\.first\.name`.

Also added a new test `Catmandu-Fix-dotted_path.t` to test this behaviour.