### PR TITLE
introduce fix compact_array

### DIFF
--- a/lib/Catmandu/Fix/compact_array.pm
+++ b/lib/Catmandu/Fix/compact_array.pm
@@ -1,0 +1,51 @@
+package Catmandu::Fix::compact_array;
+
+use Catmandu::Sane;
+use Moo;
+use Catmandu::Fix::Has;
+
+with 'Catmandu::Fix::Base';
+
+has path => (fix_arg => 1);
+
+sub emit {
+    my ($self, $fixer) = @_;
+    my $path = $fixer->split_path($self->path);
+    my $key  = pop @$path;
+
+    $fixer->emit_walk_path(
+        $fixer->var,
+        $path,
+        sub {
+            my $var = shift;
+            $fixer->emit_get_key(
+                $var, $key,
+                sub {
+                    my $var = shift;
+
+                    "if (is_array_ref(${var})) {"
+                        . "${var} = [ grep { defined \$_ } \@{${var}} ];"
+                        . "}";
+                }
+            );
+        }
+    );
+
+}
+
+=head1 NAME
+
+Catmandu::Fix::compact_array - clear invalid values from array
+
+=head1 SYNOPSIS
+
+   #array => [undef,"hello",undef,"world"]
+   #result => ['Hello','world']
+
+=head1 SEE ALSO
+
+L<Catmandu::Fix>
+
+=cut
+
+1;

--- a/t/Catmandu-Fix-compact_array.t
+++ b/t/Catmandu-Fix-compact_array.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+my $pkg;
+
+BEGIN {
+    $pkg = 'Catmandu::Fix::compact_array';
+    use_ok $pkg;
+}
+
+is_deeply $pkg->new('dirty_array')->fix(
+    { 'dirty_array' => [undef,undef,'hello',undef,'world',undef] } ),
+    { 'dirty_array' => ['hello','world'] },
+    "compactify value";
+
+is_deeply $pkg->new('dirty_array')->fix(
+    { 'dirty_array' => [undef,undef,'hello',undef,'world',undef] } ),
+    { 'dirty_array' => ['hello','world'] },
+    "compactify wildcard values";
+
+done_testing;


### PR DESCRIPTION
This is a fix introduced by @phochste or @nics in [LibreCat](https://github.com/LibreCat/LibreCat/blob/master/lib/Catmandu/Fix/compact_array.pm)

I think it should be removed from there and added to Catmandu