### PR TITLE
Changed: Fixed typo in CLI.pm.

### DIFF
--- a/lib/Catmandu/CLI.pm
+++ b/lib/Catmandu/CLI.pm
@@ -39,7 +39,7 @@ sub default_log4perl_config {
 
     my $config = <<EOF;
 log4perl.category.Catmandu=$level,$appender
-log4perl.categoty.Catmandu::Fix::log=TRACE,$appender
+log4perl.category.Catmandu::Fix::log=TRACE,$appender
 
 log4perl.appender.STDOUT=Log::Log4perl::Appender::Screen
 log4perl.appender.STDOUT.stderr=0


### PR DESCRIPTION
Fixing a typo in the log4perl configuration included in CLI.pm.