### PR TITLE
Changed: removed unused default_config_extensions subroutine.

### DIFF
--- a/lib/Catmandu/Env.pm
+++ b/lib/Catmandu/Env.pm
@@ -59,10 +59,6 @@ has fixes_namespace => (is => 'ro', default => sub {'Catmandu::Fix'})
 has importer_namespace => (is => 'ro', default => sub {'Catmandu::Importer'});
 has exporter_namespace => (is => 'ro', default => sub {'Catmandu::Exporter'});
 
-sub default_config_extensions {
-    [qw(yaml yml json pl)];
-}
-
 sub BUILD {
     my ($self) = @_;
 


### PR DESCRIPTION
Seems like the default_config_extensions() subroutine in Env.pm isn't used anywhere throughout the code. Building and testing all pass without this subroutine. So, removing this.