### PR TITLE
use generator only once in importer

### DIFF
--- a/lib/Catmandu/Importer.pm
+++ b/lib/Catmandu/Importer.pm
@@ -19,6 +19,11 @@ with 'Catmandu::Serializer';
 
 around generator => sub {
     my ($orig, $self) = @_;
+
+    return sub {} if $self->{_gen_created};
+
+    $self->{_gen_created} = 1;
+
     my $generator = $orig->($self);
 
     if (my $fixer = $self->_fixer) {


### PR DESCRIPTION
Catmandu importers cannot rewind the stream. So a call to a generator 
should be blocked. This way methods like "first" and "rest" should work
as expected (see https://github.com/LibreCat/Catmandu/issues/353)