### PR TITLE
add fix 'env'

### DIFF
--- a/lib/Catmandu/Fix/env.pm
+++ b/lib/Catmandu/Fix/env.pm
@@ -1,0 +1,58 @@
+package Catmandu::Fix::env;
+
+use Catmandu::Sane;
+
+our $VERSION = '1.2008';
+
+use Moo;
+use Catmandu::Util::Path qw(as_path);
+use namespace::clean;
+use Catmandu::Fix::Has;
+
+with 'Catmandu::Fix::Builder';
+
+has path  => (fix_arg => 1);
+has value => (fix_arg => 1, default => sub {undef});
+
+sub _build_fixer {
+    my ($self) = @_;
+    my $v = $ENV{$self->value};
+    as_path($self->path)->creator($v);
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Catmandu::Fix::env - add or change the value of a HASH key or ARRAY index via
+environment variables
+
+=head1 DESCRIPTION
+
+The C<env> fix behaves the same way as the <add_field> fix. Intermediate structures
+are created if they are missing.
+
+=head1 SYNOPSIS
+
+    # on the command line
+    $ ENV_MYVAL=bar catmandu convert Null to YAML --fix "env(foo, ENV_MYVAL)"
+    # output
+    ---
+    foo: bar
+    ...
+
+    # Add a new field 'foo' with value from ENV_MYVAL
+    env(foo, ENV_MYVAL)
+
+    # Create a deeply nested key with value from ENV_MYVAL
+    add_field(my.deep.nested.key, ENV_MYVAL)
+
+=head1 SEE ALSO
+
+L<Catmandu::Fix>
+
+=cut

--- a/t/Catmandu-Fix-env.t
+++ b/t/Catmandu-Fix-env.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+my $pkg;
+
+BEGIN {
+    $ENV{ENVTEST} = "bar";
+    $pkg = 'Catmandu::Fix::env';
+    use_ok $pkg;
+}
+
+is_deeply $pkg->new('foo', 'ENVTEST')->fix({}), {foo => "bar"},
+    "add field at root";
+
+is_deeply $pkg->new('deeply.nested.$append.job', 'ENVTEST')->fix({}),
+    {deeply => {nested => [{job => "bar"}]}},
+    "add field creates intermediate path";
+
+is_deeply $pkg->new('deeply.nested.1.job', 'ENVTEST')->fix({}),
+    {deeply => {nested => [undef, {job => "bar"}]}},
+    "add field creates intermediate path";
+
+is_deeply $pkg->new('deeply.nested.$append.job', 'ENVTEST')
+    ->fix({deeply => {nested => {}}}), {deeply => {nested => {}}},
+    "only add field if the path matches";
+
+done_testing;


### PR DESCRIPTION
Use case:

One has a fix file where one needs to add/change a field, e.g. adding a collection ID manually

This would require either changing the fix file every now and then or to follow the solution from https://librecatproject.wordpress.com/2015/05/20/preprocessing-catmandu-fixes/

Another option would be to use ENV variables:

```
$ ENV_MYVAL=bar catmandu convert Null to YAML --fix "env(foo, ENV_MYVAL)"
```

I find it quite handy, please have a look if this is useful for the rest of you.